### PR TITLE
Query engine reorg

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ serialize = []
 
 [dependencies]
 jomini = "0.2"
+once_cell = "1"
 zip = { version =  "0.5", default-features = false, features = ["deflate"] }
 serde = { version = "1", features = ["derive"] }
 tempfile = { version = "3", optional = true }

--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ let extractor = Eu4Extractor::default();
 let (save, encoding) = extractor.extract_save(Cursor::new(&data[..]))?;
 assert_eq!(encoding, Encoding::TextZip);
 assert_eq!(save.meta.player, CountryTag::from("ENG"));
-# Ok::<(), Box<dyn std::error::Error>>(())
 ```
 
 `Eu4Extractor` will deserialize both plaintext (used for mods, multiplayer,
@@ -42,11 +41,10 @@ let data = std::fs::read("assets/saves/eng.txt.compressed.eu4")?;
 let extractor = Eu4Extractor::default();
 let (save, _encoding) = extractor.extract_save(Cursor::new(&data[..]))?;
 let save_query = Query::from_save(save);
-let trade = save_query.save.game.countries.get(&CountryTag::from("ENG"))
+let trade = save_query.save().game.countries.get(&CountryTag::from("ENG"))
     .map(|country| save_query.country_income_breakdown(country))
     .map(|income| income.trade);
 assert_eq!(Some(17.982), trade);
-# Ok::<(), Box<dyn std::error::Error>>(())
 ```
 
 ## Ironman

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@ let data = std::fs::read("assets/saves/eng.txt.compressed.eu4")?;
 let extractor = Eu4Extractor::default();
 let (save, _encoding) = extractor.extract_save(Cursor::new(&data[..]))?;
 let save_query = Query::from_save(save);
-let trade = save_query.save.game.countries.get(&CountryTag::from("ENG"))
+let trade = save_query.save().game.countries.get(&CountryTag::from("ENG"))
     .map(|country| save_query.country_income_breakdown(country))
     .map(|income| income.trade);
 assert_eq!(Some(17.982), trade);

--- a/tests/ironman.rs
+++ b/tests/ironman.rs
@@ -25,16 +25,16 @@ fn test_eu4_bin() {
     assert!(save2.game.is_none());
 
     let query = Query::from_save(save);
-    assert_eq!(query.starting_country, Some(CountryTag::from("RAG")));
+    assert_eq!(query.starting_country(), Some(&CountryTag::from("RAG")));
     assert_eq!(
-        query.players.iter().cloned().collect::<Vec<String>>(),
+        query.players().iter().cloned().collect::<Vec<String>>(),
         Vec::<String>::new()
     );
 
     let mut players = HashSet::new();
     players.insert(CountryTag::from("RAG"));
     players.insert(CountryTag::from("CRO"));
-    assert_eq!(query.player_countries, players);
+    assert_eq!(query.player_countries(), &players);
 }
 
 #[test]
@@ -49,9 +49,9 @@ fn test_eu4_kandy_bin() {
     let mut players = HashSet::new();
     players.insert(CountryTag::from("KND"));
     players.insert(CountryTag::from("BHA"));
-    assert_eq!(query.player_countries, players);
+    assert_eq!(query.player_countries(), &players);
     assert!(!query
-        .save
+        .save()
         .game
         .countries
         .get(&CountryTag::from("BHA"))
@@ -66,7 +66,7 @@ fn test_eu4_kandy_bin() {
 
     assert_eq!(
         query
-            .save
+            .save()
             .game
             .provinces
             .get(&ProvinceId::from(1))
@@ -77,9 +77,9 @@ fn test_eu4_kandy_bin() {
         &CountryTag::from("SCA")
     );
 
-    assert_eq!(query.starting_country, Some(CountryTag::from("KND")));
+    assert_eq!(query.starting_country(), Some(&CountryTag::from("KND")));
     assert_eq!(
-        query.players.iter().cloned().collect::<Vec<_>>(),
+        query.players().iter().cloned().collect::<Vec<_>>(),
         vec![String::from("comagoosie")]
     );
 
@@ -92,7 +92,7 @@ fn test_eu4_kandy_bin() {
 
     assert_eq!(
         query
-            .save
+            .save()
             .game
             .countries
             .get(&CountryTag::from("BHA"))
@@ -117,7 +117,7 @@ fn test_eu4_kandy_bin() {
 
     // Testing binary encoded saves can extract province building history perfectly fine
     let london = query
-        .save
+        .save()
         .game
         .provinces
         .get(&ProvinceId::from(236))
@@ -147,7 +147,7 @@ fn test_eu4_kandy_bin() {
         .province_building_history(london)
         .get("fort_15th")
         .cloned();
-    assert_eq!(building_date, Some(query.save.game.start_date));
+    assert_eq!(building_date, Some(query.save().game.start_date));
 }
 
 #[test]
@@ -184,9 +184,9 @@ fn test_eu4_ita1() {
     assert!(all_dlc_recognized);
 
     let query = Query::from_save(save);
-    assert_eq!(query.starting_country, Some(CountryTag::from("LAN")));
+    assert_eq!(query.starting_country(), Some(&CountryTag::from("LAN")));
     assert_eq!(
-        query.players.iter().cloned().collect::<Vec<_>>(),
+        query.players().iter().cloned().collect::<Vec<_>>(),
         vec![String::from("comagoosie")]
     );
 }
@@ -236,7 +236,7 @@ macro_rules! ironman_test {
                 let query = Query::from_save(save);
 
                 assert_eq!(
-                    query.starting_country.as_ref().unwrap(),
+                    query.starting_country().unwrap(),
                     &CountryTag::from(expected.starting)
                 );
 
@@ -317,7 +317,7 @@ ironman_test!(
     },
     |query: Query| {
         assert_eq!(
-            query.players.iter().cloned().collect::<Vec<_>>(),
+            query.players().iter().cloned().collect::<Vec<_>>(),
             vec![String::from("comagoosie")]
         );
     }

--- a/tests/samples.rs
+++ b/tests/samples.rs
@@ -21,14 +21,14 @@ fn test_eu4_text() {
     assert_eq!(save.meta.player, CountryTag::from("ENG"));
 
     let query = Query::from_save(save);
-    assert_eq!(query.starting_country, Some(CountryTag::from("ENG")));
+    assert_eq!(query.starting_country(), Some(&CountryTag::from("ENG")));
     assert_eq!(
-        query.players.iter().cloned().collect::<Vec<String>>(),
+        query.players().iter().cloned().collect::<Vec<String>>(),
         Vec::<String>::new()
     );
 
     let london = query
-        .save
+        .save()
         .game
         .provinces
         .get(&ProvinceId::from(236))


### PR DESCRIPTION
There were a couple unsatisfactory elements of the query engine.

- Public fields which goes against C-STRUCT-PRIVATE
- Switch to computing cached data on demand instead of pre-emptively.
This will allow eu4save to start caching a lot of computations. One of
this is for calculating the timeline of which buildings have been built,
which requires looking at all the provinces. If someone never looks at
building info, then they shouldn't need to pay that caching operation
cost.