### PR TITLE
Rework Eu4Extraction constructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,7 @@ use eu4save::{Eu4Extractor, Encoding, CountryTag};
 use std::io::Cursor;
 
 let data = std::fs::read("assets/saves/eng.txt.compressed.eu4")?;
-let extractor = Eu4Extractor::default();
-let (save, encoding) = extractor.extract_save(Cursor::new(&data[..]))?;
+let (save, encoding) = Eu4Extractor::extract_save(Cursor::new(&data[..]))?;
 assert_eq!(encoding, Encoding::TextZip);
 assert_eq!(save.meta.player, CountryTag::from("ENG"));
 ```
@@ -38,8 +37,7 @@ use eu4save::{Eu4Extractor, Encoding, CountryTag, query::Query};
 use std::io::Cursor;
 
 let data = std::fs::read("assets/saves/eng.txt.compressed.eu4")?;
-let extractor = Eu4Extractor::default();
-let (save, _encoding) = extractor.extract_save(Cursor::new(&data[..]))?;
+let (save, _encoding) = Eu4Extractor::extract_save(Cursor::new(&data[..]))?;
 let save_query = Query::from_save(save);
 let trade = save_query.save().game.countries.get(&CountryTag::from("ENG"))
     .map(|country| save_query.country_income_breakdown(country))

--- a/fuzz/fuzz_targets/fuzz_extract.rs
+++ b/fuzz/fuzz_targets/fuzz_extract.rs
@@ -3,6 +3,5 @@ use libfuzzer_sys::fuzz_target;
 use std::io::Cursor;
 
 fuzz_target!(|data: &[u8]| {
-    let extractor = eu4save::Eu4Extractor::default();
-    let _ = extractor.extract_save(Cursor::new(&data[..]));
+    let _ = eu4save::Eu4Extractor::extract_save(Cursor::new(&data[..]));
 });

--- a/src/bin/debug_save.rs
+++ b/src/bin/debug_save.rs
@@ -7,8 +7,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args: Vec<String> = env::args().collect();
     let file = File::open(&args[1])?;
     let reader = BufReader::new(file);
-    let extractor = Eu4Extractor::default();
-    let (save, _encoding) = extractor.extract_save(reader)?;
+    let (save, _encoding) = Eu4Extractor::extract_save(reader)?;
     print!("{:#?}", save.meta.date);
     Ok(())
 }

--- a/src/bin/deducer.rs
+++ b/src/bin/deducer.rs
@@ -48,8 +48,7 @@ fn deduce_vec(save: &Eu4Save, f: impl Fn(&Country) -> &[f32]) {
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args: Vec<String> = env::args().collect();
     let data = std::fs::read(&args[1])?;
-    let extractor = Eu4Extractor::default();
-    let (save, _encoding) = extractor.extract_save(Cursor::new(&data[..]))?;
+    let (save, _encoding) = Eu4Extractor::extract_save(Cursor::new(&data[..]))?;
     deduce_vec(&save, |c| &c.ledger.income);
     deduce_vec(&save, |c| &c.ledger.expense);
 

--- a/src/extraction.rs
+++ b/src/extraction.rs
@@ -67,27 +67,6 @@ impl Eu4ExtractorBuilder {
         self
     }
 
-    pub fn build(self) -> Eu4Extractor {
-        Eu4Extractor {
-            extraction: self.extraction,
-            on_failed_resolve: self.on_failed_resolve,
-        }
-    }
-}
-
-#[derive(Debug, Clone)]
-pub struct Eu4Extractor {
-    extraction: Extraction,
-    on_failed_resolve: FailedResolveStrategy,
-}
-
-impl Default for Eu4Extractor {
-    fn default() -> Self {
-        Eu4ExtractorBuilder::new().build()
-    }
-}
-
-impl Eu4Extractor {
     pub fn extract_meta<R>(&self, mut reader: R) -> Result<(Meta, Encoding), Eu4Error>
     where
         R: Read + Seek,
@@ -206,6 +185,38 @@ impl Eu4Extractor {
         } else {
             Err(Eu4ErrorKind::UnknownHeader.into())
         }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Eu4Extractor {}
+
+impl Eu4Extractor {
+    pub fn builder() -> Eu4ExtractorBuilder {
+        Eu4ExtractorBuilder::new()
+    }
+
+    pub fn extract_meta<R>(reader: R) -> Result<(Meta, Encoding), Eu4Error>
+    where
+        R: Read + Seek,
+    {
+        Self::builder().extract_meta(reader)
+    }
+
+    pub fn extract_save<R>(reader: R) -> Result<(Eu4Save, Encoding), Eu4Error>
+    where
+        R: Read + Seek,
+    {
+        Self::builder().extract_save(reader)
+    }
+
+    // For the times where all you want is the metadata but will accept the game state too save on
+    // future needless double parsing.
+    pub fn extract_meta_optimistic<R>(reader: R) -> Result<(Eu4SaveMeta, Encoding), Eu4Error>
+    where
+        R: Read + Seek,
+    {
+        Self::builder().extract_meta_optimistic(reader)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,8 +6,7 @@ use eu4save::{Eu4Extractor, Encoding, CountryTag};
 use std::io::Cursor;
 
 let data = std::fs::read("assets/saves/eng.txt.compressed.eu4")?;
-let extractor = Eu4Extractor::default();
-let (save, encoding) = extractor.extract_save(Cursor::new(&data[..]))?;
+let (save, encoding) = Eu4Extractor::extract_save(Cursor::new(&data[..]))?;
 assert_eq!(encoding, Encoding::TextZip);
 assert_eq!(save.meta.player, CountryTag::from("ENG"));
 # Ok::<(), Box<dyn std::error::Error>>(())
@@ -36,8 +35,7 @@ use eu4save::{Eu4Extractor, Encoding, CountryTag, query::Query};
 use std::io::Cursor;
 
 let data = std::fs::read("assets/saves/eng.txt.compressed.eu4")?;
-let extractor = Eu4Extractor::default();
-let (save, _encoding) = extractor.extract_save(Cursor::new(&data[..]))?;
+let (save, _encoding) = Eu4Extractor::extract_save(Cursor::new(&data[..]))?;
 let save_query = Query::from_save(save);
 let trade = save_query.save().game.countries.get(&CountryTag::from("ENG"))
     .map(|country| save_query.country_income_breakdown(country))

--- a/tests/crashes.rs
+++ b/tests/crashes.rs
@@ -4,6 +4,5 @@ use std::io::Cursor;
 #[test]
 fn fix_crash_on_long_country_tag_debug_mode() {
     let data = include_bytes!("fixtures/crash1.bin");
-    let extractor = Eu4Extractor::default();
-    let _ = extractor.extract_save(Cursor::new(&data[..]));
+    let _ = Eu4Extractor::extract_save(Cursor::new(&data[..]));
 }

--- a/tests/ironman.rs
+++ b/tests/ironman.rs
@@ -14,14 +14,11 @@ mod utils;
 #[test]
 fn test_eu4_bin() {
     let data = utils::request("ragusa2.bin.eu4");
-    let extractor = Eu4Extractor::default();
-    let (save, encoding) = extractor.extract_save(Cursor::new(&data[..])).unwrap();
+    let (save, encoding) = Eu4Extractor::extract_save(Cursor::new(&data[..])).unwrap();
     assert_eq!(encoding, Encoding::BinZip);
     assert_eq!(save.meta.player, CountryTag::from("CRO"));
 
-    let (save2, _) = extractor
-        .extract_meta_optimistic(Cursor::new(&data[..]))
-        .unwrap();
+    let (save2, _) = Eu4Extractor::extract_meta_optimistic(Cursor::new(&data[..])).unwrap();
     assert!(save2.game.is_none());
 
     let query = Query::from_save(save);
@@ -40,8 +37,7 @@ fn test_eu4_bin() {
 #[test]
 fn test_eu4_kandy_bin() {
     let data = utils::request("kandy2.bin.eu4");
-    let extractor = Eu4Extractor::default();
-    let (save, encoding) = extractor.extract_save(Cursor::new(&data[..])).unwrap();
+    let (save, encoding) = Eu4Extractor::extract_save(Cursor::new(&data[..])).unwrap();
     assert_eq!(encoding, Encoding::BinZip);
     assert_eq!(save.meta.player, CountryTag::from("BHA"));
 
@@ -154,9 +150,8 @@ fn test_eu4_kandy_bin() {
 fn test_eu4_same_campaign_id() {
     let data = utils::request("ita2.eu4");
     let data2 = utils::request("ita2_later.eu4");
-    let extractor = Eu4Extractor::default();
-    let (save, _) = extractor.extract_save(Cursor::new(&data[..])).unwrap();
-    let (save2, _) = extractor.extract_save(Cursor::new(&data2[..])).unwrap();
+    let (save, _) = Eu4Extractor::extract_save(Cursor::new(&data[..])).unwrap();
+    let (save2, _) = Eu4Extractor::extract_save(Cursor::new(&data2[..])).unwrap();
     assert_eq!(save.meta.campaign_id, save2.meta.campaign_id);
     assert!(save.meta.date < save2.meta.date);
 }
@@ -164,8 +159,7 @@ fn test_eu4_same_campaign_id() {
 #[test]
 fn test_eu4_ita1() {
     let data = utils::request("ita1.eu4");
-    let extractor = Eu4Extractor::default();
-    let (save, encoding) = extractor.extract_save(Cursor::new(&data[..])).unwrap();
+    let (save, encoding) = Eu4Extractor::extract_save(Cursor::new(&data[..])).unwrap();
     assert_eq!(encoding, Encoding::BinZip);
     assert_eq!(save.meta.player, CountryTag::from("ITA"));
     let settings = &save.game.gameplay_settings.options;
@@ -195,8 +189,7 @@ fn test_eu4_ita1() {
 fn test_roundtrip_melt() {
     let data = utils::request("kandy2.bin.eu4");
     let out = eu4save::melt(&data[..], eu4save::FailedResolveStrategy::Error).unwrap();
-    let extractor = Eu4Extractor::default();
-    let (save, encoding) = extractor.extract_save(Cursor::new(&out[..])).unwrap();
+    let (save, encoding) = Eu4Extractor::extract_save(Cursor::new(&out[..])).unwrap();
     assert_eq!(encoding, Encoding::Text);
     assert_eq!(save.meta.player, CountryTag::from("BHA"));
 }
@@ -214,10 +207,10 @@ macro_rules! ironman_test {
                 let melted = eu4save::melt(&data[..], FailedResolveStrategy::Error).unwrap();
                 assert!(!melted.is_empty());
 
-                let extractor = Eu4ExtractorBuilder::new()
+                let (save, encoding) = Eu4ExtractorBuilder::new()
                     .with_on_failed_resolve(FailedResolveStrategy::Error)
-                    .build();
-                let (save, encoding) = extractor.extract_save(Cursor::new(&data[..])).unwrap();
+                    .extract_save(Cursor::new(&data[..]))
+                    .unwrap();
                 assert_eq!(encoding, Encoding::BinZip);
                 let expected = $query;
                 assert_eq!(save.meta.player, CountryTag::from(expected.player));

--- a/tests/samples.rs
+++ b/tests/samples.rs
@@ -15,8 +15,7 @@ fn test_eu4_text() {
     let mut zip_file = zip.by_index(0).unwrap();
     let mut buffer = Vec::with_capacity(0);
     zip_file.read_to_end(&mut buffer).unwrap();
-    let extractor = Eu4Extractor::default();
-    let (save, encoding) = extractor.extract_save(Cursor::new(&buffer)).unwrap();
+    let (save, encoding) = Eu4Extractor::extract_save(Cursor::new(&buffer)).unwrap();
     assert_eq!(encoding, Encoding::Text);
     assert_eq!(save.meta.player, CountryTag::from("ENG"));
 
@@ -39,35 +38,30 @@ fn test_eu4_text() {
         Some(&CountryTag::from("ENG"))
     );
 
-    let (save, _) = extractor
-        .extract_meta_optimistic(Cursor::new(&buffer))
-        .unwrap();
+    let (save, _) = Eu4Extractor::extract_meta_optimistic(Cursor::new(&buffer)).unwrap();
     assert!(save.game.is_some());
 }
 
 #[test]
 fn test_eu4_compressed_text() {
     let data = utils::request("eng.txt.compressed.eu4");
-    let extractor = Eu4Extractor::default();
-    let (save, encoding) = extractor.extract_save(Cursor::new(&data[..])).unwrap();
+    let (save, encoding) = Eu4Extractor::extract_save(Cursor::new(&data[..])).unwrap();
     assert_eq!(encoding, Encoding::TextZip);
     assert_eq!(save.meta.player, CountryTag::from("ENG"));
 
-    let (save, _) = extractor
-        .extract_meta_optimistic(Cursor::new(&data[..]))
-        .unwrap();
+    let (save, _) = Eu4Extractor::extract_meta_optimistic(Cursor::new(&data[..])).unwrap();
     assert!(save.game.is_none());
 }
 
 #[cfg(feature = "mmap")]
 #[test]
 fn test_eu4_compressed_text_mmap() {
-    use eu4save::{Eu4ExtractorBuilder, Extraction};
+    use eu4save::Extraction;
     let data = utils::request("eng.txt.compressed.eu4");
-    let extractor = Eu4ExtractorBuilder::new()
+    let (save, encoding) = Eu4Extractor::builder()
         .with_extraction(Extraction::MmapTemporaries)
-        .build();
-    let (save, encoding) = extractor.extract_save(Cursor::new(&data[..])).unwrap();
+        .extract_save(Cursor::new(&data[..]))
+        .unwrap();
     assert_eq!(encoding, Encoding::TextZip);
     assert_eq!(save.meta.player, CountryTag::from("ENG"));
 }
@@ -75,8 +69,7 @@ fn test_eu4_compressed_text_mmap() {
 #[test]
 pub fn parse_multiplayer_saves() -> Result<(), Box<dyn Error>> {
     let data = utils::request("mp_Uesugi.eu4");
-    let extractor = Eu4Extractor::default();
-    let (save, _encoding) = extractor.extract_save(Cursor::new(&data[..])).unwrap();
+    let (save, _encoding) = Eu4Extractor::extract_save(Cursor::new(&data[..])).unwrap();
     assert!(save.meta.multiplayer);
 
     // Testing text encoded saves can extract province building history perfectly fine
@@ -106,8 +99,7 @@ fn test_missing_leader_activation_save() {
     let mut buffer = Vec::with_capacity(0);
     zip_file.read_to_end(&mut buffer).unwrap();
 
-    let extractor = Eu4Extractor::default();
-    let (save, encoding) = extractor.extract_save(Cursor::new(&buffer[..])).unwrap();
+    let (save, encoding) = Eu4Extractor::extract_save(Cursor::new(&buffer[..])).unwrap();
     assert_eq!(encoding, Encoding::Text);
     assert_eq!(save.meta.player, CountryTag::from("NED"));
 
@@ -136,7 +128,6 @@ fn test_handle_heavily_nested_events() {
     // "flavor_eng.9880" or the symposium event for great britain where every ten years the event
     // fires. https://eu4.paradoxwikis.com/English_events#Symposium
     let data = utils::request("HashMP_Game56_S7End.eu4");
-    let extractor = Eu4Extractor::default();
-    let (_save, encoding) = extractor.extract_save(Cursor::new(&data[..])).unwrap();
+    let (_save, encoding) = Eu4Extractor::extract_save(Cursor::new(&data[..])).unwrap();
     assert_eq!(encoding, Encoding::TextZip);
 }


### PR DESCRIPTION
It doesn't need a reference to self if the builder can handle extraction
natively