### PR TITLE
Use anonymous maps instead of a temporary file for mmap extraction

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["eu4", "ironman"]
 categories = ["parsing"]
 
 [features]
-mmap = ['memmap', 'tempfile']
+mmap = ['memmap']
 serialize = []
 
 [dependencies]
@@ -20,7 +20,6 @@ jomini = "0.2"
 once_cell = "1"
 zip = { version =  "0.5", default-features = false, features = ["deflate"] }
 serde = { version = "1", features = ["derive"] }
-tempfile = { version = "3", optional = true }
 memmap = { version = "0.7", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
- Gets rid of the temporary files and the (optional) dependency tempfile
- Remove the last usage of `unsafe`
- Is less code
- Performance is not impacted

Some performance numbers using `debug_save` bin

new memmap: 0m0.544s
old memmap: 0m0.551s
no memmap:  0m0.539