### PR TITLE
Move data structs behind model module

### DIFF
--- a/src/bin/deducer.rs
+++ b/src/bin/deducer.rs
@@ -1,4 +1,7 @@
-use eu4save::{Country, Eu4Extractor, Eu4Save};
+use eu4save::{
+    models::{Country, Eu4Save},
+    Eu4Extractor,
+};
 use std::collections::HashSet;
 use std::env;
 use std::io::Cursor;

--- a/src/country_tag.rs
+++ b/src/country_tag.rs
@@ -1,6 +1,7 @@
 use serde::{de, Deserialize, Deserializer, Serialize};
 use std::fmt;
 
+/// Wrapper around a Country's unique three character tag
 #[derive(Debug, Clone, Serialize, Hash, Eq, PartialEq)]
 pub struct CountryTag(String);
 

--- a/src/de/country_events.rs
+++ b/src/de/country_events.rs
@@ -1,4 +1,4 @@
-use crate::{CountryEvent, CountryEvents};
+use crate::models::{CountryEvent, CountryEvents};
 use serde::{de, Deserialize, Deserializer};
 use std::fmt;
 

--- a/src/de/country_history.rs
+++ b/src/de/country_history.rs
@@ -1,4 +1,4 @@
-use crate::{CountryHistory, Eu4Date};
+use crate::{models::CountryHistory, Eu4Date};
 use serde::{de, Deserialize, Deserializer};
 use std::fmt;
 

--- a/src/de/gameplay_settings.rs
+++ b/src/de/gameplay_settings.rs
@@ -1,4 +1,4 @@
-use crate::{GameDifficulty, GameplayOptions, TaxManpowerModifier};
+use crate::models::{GameDifficulty, GameplayOptions, TaxManpowerModifier};
 use serde::{de, Deserialize, Deserializer};
 use std::fmt;
 

--- a/src/de/leader_kind.rs
+++ b/src/de/leader_kind.rs
@@ -1,4 +1,4 @@
-use crate::LeaderKind;
+use crate::models::LeaderKind;
 use serde::{de, Deserialize, Deserializer};
 use std::fmt;
 

--- a/src/de/province_event_value.rs
+++ b/src/de/province_event_value.rs
@@ -1,4 +1,4 @@
-use crate::ProvinceEventValue;
+use crate::models::ProvinceEventValue;
 use serde::{de, Deserialize, Deserializer};
 use std::fmt;
 

--- a/src/de/province_events.rs
+++ b/src/de/province_events.rs
@@ -1,4 +1,4 @@
-use crate::{ProvinceEvent, ProvinceEvents};
+use crate::models::{ProvinceEvent, ProvinceEvents};
 use serde::{de, Deserialize, Deserializer};
 use std::fmt;
 

--- a/src/de/province_history.rs
+++ b/src/de/province_history.rs
@@ -1,4 +1,4 @@
-use crate::{Eu4Date, ProvinceHistory};
+use crate::{models::ProvinceHistory, Eu4Date};
 use serde::{de, Deserialize, Deserializer};
 use std::collections::HashMap;
 use std::fmt;

--- a/src/de/war_events.rs
+++ b/src/de/war_events.rs
@@ -1,4 +1,4 @@
-use crate::{WarEvent, WarEvents};
+use crate::models::{WarEvent, WarEvents};
 use serde::{de, Deserialize, Deserializer};
 use std::fmt;
 

--- a/src/de/war_history.rs
+++ b/src/de/war_history.rs
@@ -1,4 +1,4 @@
-use crate::{Eu4Date, WarHistory};
+use crate::{models::WarHistory, Eu4Date};
 use serde::{de, Deserialize, Deserializer};
 use std::fmt;
 

--- a/src/eu4date.rs
+++ b/src/eu4date.rs
@@ -12,7 +12,7 @@ pub const EU4_START_DATE: Eu4Date = Eu4Date {
 
 const DAYS_PER_MONTH: [u8; 13] = [0, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
 
-/// A date in EU4
+/// Struct specialized to parsing, formatting, and manipulating dates in EU4
 ///
 /// A date in EU4 does not follow any traditional calendar and instead views the
 /// world on simpler terms: that every year should be treated as a non-leap year.

--- a/src/extraction.rs
+++ b/src/extraction.rs
@@ -1,7 +1,5 @@
-use crate::{
-    Eu4Error, Eu4ErrorKind, Eu4Save, Eu4SaveMeta, FailedResolveStrategy, GameState, Meta,
-    TokenLookup,
-};
+use crate::models::{Eu4Save, Eu4SaveMeta, GameState, Meta};
+use crate::{tokens::TokenLookup, Eu4Error, Eu4ErrorKind, FailedResolveStrategy};
 use jomini::{BinaryDeserializerBuilder, TextDeserializer, TextTape};
 use serde::de::DeserializeOwned;
 use std::fmt;
@@ -30,9 +28,15 @@ impl fmt::Display for Encoding {
     }
 }
 
+/// The memory allocation strategy for handling zip files
+///
+/// When the `mmap` feature is enabled, the
 #[derive(Debug, Clone, Copy)]
 pub enum Extraction {
+    /// Extract the zip data into memory
     InMemory,
+
+    /// Extract the zip data into a temporary file that is memmapped
     #[cfg(feature = "mmap")]
     MmapTemporaries,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,21 +65,25 @@ You may look to other projects EU4 ironman projects like ironmelt or paperman
 for inspiration.
 */
 
+mod country_tag;
 mod de;
 mod dlc;
 mod errors;
 mod eu4date;
 mod extraction;
 mod melt;
-mod models;
+/// Repository of raw structs extracted from a save file
+pub mod models;
+mod province_id;
+/// Ergonomic module for querying info from a save file
 pub mod query;
 mod tokens;
 
+pub use country_tag::*;
+pub use dlc::*;
 pub use errors::*;
 pub use eu4date::*;
 pub use extraction::*;
 pub use jomini::FailedResolveStrategy;
 pub use melt::*;
-pub use models::*;
-pub use tokens::*;
-pub use dlc::*;
+pub use province_id::*;

--- a/src/melt.rs
+++ b/src/melt.rs
@@ -1,4 +1,4 @@
-use crate::{Eu4Date, Eu4Error, Eu4ErrorKind, TokenLookup};
+use crate::{tokens::TokenLookup, Eu4Date, Eu4Error, Eu4ErrorKind};
 use jomini::{BinaryTape, BinaryToken, FailedResolveStrategy, TokenResolver};
 use std::io::{Cursor, Read, Write};
 

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,13 +1,8 @@
 use crate::de::*;
-use crate::Eu4Date;
+use crate::{CountryTag, Eu4Date, ProvinceId};
 use jomini::JominiDeserialize;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-
-mod country_tag;
-mod province_id;
-pub use country_tag::*;
-pub use province_id::*;
 
 #[derive(Debug, Clone, Deserialize)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]

--- a/src/province_id.rs
+++ b/src/province_id.rs
@@ -1,6 +1,13 @@
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
+/// An province numerical identifier
+///
+/// Handles negative identifiers by taking their absolute value.
+///
+/// ```rust
+/// let _ = eu4save::ProvinceId::new(10);
+/// ```
 #[derive(Debug, Clone, Serialize, Hash, Eq, PartialEq, Default, Deserialize)]
 #[serde(from = "i32")]
 pub struct ProvinceId(i32);

--- a/src/query.rs
+++ b/src/query.rs
@@ -1,7 +1,7 @@
-use crate::{
-    Country, CountryEvent, CountryTag, Eu4Date, Eu4Save, LedgerData, LedgerDatum, Province,
-    ProvinceEvent,
+use crate::models::{
+    Country, CountryEvent, Eu4Save, LedgerData, LedgerDatum, Province, ProvinceEvent,
 };
+use crate::{CountryTag, Eu4Date};
 use once_cell::sync::OnceCell;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};

--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -1,6 +1,6 @@
 use jomini::TokenResolver;
 
-pub struct TokenLookup;
+pub(crate) struct TokenLookup;
 
 impl TokenResolver for TokenLookup {
     fn resolve(&self, token: u16) -> Option<&str> {

--- a/tests/ironman.rs
+++ b/tests/ironman.rs
@@ -1,9 +1,10 @@
 #![cfg(ironman)]
 
+use eu4save::models::{GameDifficulty, ProvinceEvent, ProvinceEventValue, TaxManpowerModifier};
 use eu4save::{
     query::{CountryQuery, Query},
     CountryTag, Encoding, Eu4Date, Eu4Extractor, Eu4ExtractorBuilder, FailedResolveStrategy,
-    GameDifficulty, ProvinceEvent, ProvinceEventValue, ProvinceId, TaxManpowerModifier,
+    ProvinceId,
 };
 use paste::paste;
 use std::collections::HashSet;

--- a/tests/samples.rs
+++ b/tests/samples.rs
@@ -1,7 +1,5 @@
-use eu4save::{
-    query::Query, CountryEvent, CountryTag, Encoding, Eu4Extractor, ProvinceEvent,
-    ProvinceEventValue, ProvinceId,
-};
+use eu4save::models::{CountryEvent, ProvinceEvent, ProvinceEventValue};
+use eu4save::{query::Query, CountryTag, Encoding, Eu4Extractor, ProvinceId};
 use std::error::Error;
 use std::io::{Cursor, Read};
 


### PR DESCRIPTION
There were too many structs in the root module and it started to detract
from more common and appropriate structs like Eu4Extractor and Eu4Date
and CountryTag, etc.