### PR TITLE
Simplify test S3 file retrieval

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ serde = { version = "1", features = ["derive"] }
 memmap = { version = "0.7", optional = true }
 
 [dev-dependencies]
-rust-s3 = "0.26"
+attohttpc = "0.16"
 paste = "1"
 criterion = "0.3"
 


### PR DESCRIPTION
No need to use a complicated stack when a simple HTTP client will
suffice. Applying this change across the rakaly code base is shaving 40%
off CI times