### PR TITLE
Rework CountryTag to validate inline storage

### DIFF
--- a/src/bin/deducer.rs
+++ b/src/bin/deducer.rs
@@ -1,16 +1,16 @@
-use eu4save::Eu4Extractor;
+use eu4save::{CountryTag, Eu4Extractor};
 use std::env;
 use std::io::Cursor;
 use std::{collections::HashSet, fmt::Display};
 
 #[derive(Debug)]
 struct Deduce<N> {
-    country: String,
+    country: CountryTag,
     index: usize,
     value: N,
 }
 
-fn deduce_vec<'a, N>(iter: impl Iterator<Item = (&'a str, &'a [N])>)
+fn deduce_vec<'a, N>(iter: impl Iterator<Item = (CountryTag, &'a [N])>)
 where
     N: 'a + PartialEq + Default + Display,
 {
@@ -27,7 +27,7 @@ where
                 ded.push(Deduce {
                     index: i,
                     value,
-                    country: tag.to_string(),
+                    country: tag,
                 });
             }
         }
@@ -55,20 +55,20 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         save.game
             .countries
             .iter()
-            .map(|(tag, c)| (tag.as_str(), c.ledger.income.as_slice())),
+            .map(|(&tag, c)| (tag, c.ledger.income.as_slice())),
     );
     deduce_vec(
         save.game
             .countries
             .iter()
-            .map(|(tag, c)| (tag.as_str(), c.ledger.expense.as_slice())),
+            .map(|(&tag, c)| (tag, c.ledger.expense.as_slice())),
     );
     deduce_vec(
         save.game
             .countries
             .iter()
             .filter(|(_tag, c)| c.num_of_cities > 0)
-            .map(|(tag, c)| (tag.as_str(), c.losses.members.as_slice())),
+            .map(|(&tag, c)| (tag, c.losses.members.as_slice())),
     );
 
     Ok(())

--- a/src/country_tag.rs
+++ b/src/country_tag.rs
@@ -1,46 +1,114 @@
-use serde::{de, Deserialize, Deserializer, Serialize};
-use std::fmt;
+use crate::{Eu4Error, Eu4ErrorKind};
+use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
+use std::{fmt, str::FromStr};
 
-/// Wrapper around a Country's unique three character tag
-#[derive(Debug, Clone, Serialize, Hash, Eq, PartialEq, PartialOrd, Ord)]
-pub struct CountryTag(String);
+/// Wrapper around a Country's unique three byte tag
+///
+/// ```rust
+/// use eu4save::CountryTag;
+/// let tag: CountryTag = "ENG".parse()?;
+/// assert_eq!(tag.to_string(), String::from("ENG"));
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
+#[derive(Clone, Copy, Hash, Eq, PartialEq, PartialOrd, Ord)]
+pub struct CountryTag([u8; 3]);
 
 impl CountryTag {
-    pub fn new(x: String) -> Self {
-        debug_assert!(
-            x.len() == 3,
-            "expected country tag {} to be 3 characters",
-            x
-        );
-        CountryTag(x)
+    /// Create a country tag from a byte slice. Returns error if input is not
+    /// three bytes in length and not compose of dashes or alphanumeric data.
+    ///
+    /// ```
+    /// use eu4save::CountryTag;
+    /// let tag: CountryTag = CountryTag::create(b"ENG")?;
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    pub fn create<T: AsRef<[u8]>>(s: T) -> Result<Self, Eu4Error> {
+        if let [a, b, c] = *s.as_ref() {
+            if is_tagc(a) && is_tagc(b) && is_tagc(c) {
+                Ok(CountryTag([a, b, c]))
+            } else {
+                Err(Eu4Error::new(Eu4ErrorKind::CountryTagInvalidCharacters))
+            }
+        } else {
+            Err(Eu4Error::new(Eu4ErrorKind::CountryTagIncorrectSize))
+        }
     }
 
+    /// An ergonomic shortcut to determine if input byte slice contains the same
+    /// data as the tag
+    /// ```
+    /// use eu4save::CountryTag;
+    /// let tag: CountryTag = CountryTag::create(b"ENG")?;
+    /// assert!(tag.is(b"ENG"));
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    pub fn is<T: AsRef<[u8]>>(&self, s: T) -> bool {
+        self.as_bytes() == s.as_ref()
+    }
+
+    /// Returns the country tag as a byte slice
+    /// ```
+    /// use eu4save::CountryTag;
+    /// let tag: CountryTag = CountryTag::create(b"ENG")?;
+    /// assert_eq!(tag.as_bytes(), b"ENG");
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.0
+    }
+
+    /// Returns the country tag as a string slice
+    /// ```
+    /// use eu4save::CountryTag;
+    /// let tag: CountryTag = CountryTag::create(b"ENG")?;
+    /// assert_eq!(tag.as_str(), "ENG");
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
     pub fn as_str(&self) -> &str {
-        self.0.as_str()
+        // We know that this is safe as the CountryTag constructor only allows
+        // ascii alphanumeric and dashes
+        debug_assert!(std::str::from_utf8(&self.0).is_ok());
+        unsafe { std::str::from_utf8_unchecked(&self.0) }
     }
 }
 
-impl<'a> From<&'a str> for CountryTag {
-    fn from(x: &'a str) -> Self {
-        CountryTag::from(String::from(x))
+#[inline]
+pub const fn is_tagc(b: u8) -> bool {
+    b.is_ascii_alphanumeric() || b == b'-'
+}
+
+impl FromStr for CountryTag {
+    type Err = Eu4Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        CountryTag::create(s)
     }
 }
 
-impl From<String> for CountryTag {
-    fn from(x: String) -> Self {
-        CountryTag::new(x)
+impl AsRef<str> for CountryTag {
+    fn as_ref(&self) -> &str {
+        self.as_str()
     }
 }
 
-impl Into<String> for CountryTag {
-    fn into(self) -> String {
-        self.0
+impl fmt::Debug for CountryTag {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_ref())
     }
 }
 
 impl fmt::Display for CountryTag {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.0)
+        f.write_str(self.as_ref())
+    }
+}
+
+impl Serialize for CountryTag {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(self.as_ref())
     }
 }
 
@@ -62,13 +130,7 @@ impl<'de> Deserialize<'de> for CountryTag {
             where
                 A: de::Error,
             {
-                if v.len() != 3 {
-                    Err(de::Error::custom(
-                        "a country tag should be a sequence of 3 letters",
-                    ))
-                } else {
-                    Ok(CountryTag::from(v))
-                }
+                v.parse().map_err(de::Error::custom)
             }
         }
 
@@ -82,6 +144,21 @@ mod tests {
 
     #[test]
     fn tag_order() {
-        assert!(CountryTag::from("AAA") < CountryTag::from("BBB"));
+        let tag1: CountryTag = "AAA".parse().unwrap();
+        let tag2: CountryTag = "BBB".parse().unwrap();
+        assert!(tag1 < tag2);
+    }
+
+    #[test]
+    fn parse_blank_tag() {
+        let tag1: CountryTag = "---".parse().unwrap();
+        assert_eq!(tag1.to_string(), String::from("---"));
+    }
+
+    #[test]
+    fn tag_debug_representation() {
+        let tag1: CountryTag = "FRA".parse().unwrap();
+        let debug = format!("{:?}", tag1);
+        assert_eq!(debug, String::from("FRA"));
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -33,6 +33,8 @@ pub enum Eu4ErrorKind {
         part: Option<String>,
         err: jomini::Error,
     },
+    CountryTagIncorrectSize,
+    CountryTagInvalidCharacters,
 }
 
 impl fmt::Display for Eu4Error {
@@ -53,6 +55,12 @@ impl fmt::Display for Eu4Error {
                 Some(p) => write!(f, "error deserializing: {}: {}", p, err),
                 None => err.fmt(f),
             },
+            Eu4ErrorKind::CountryTagIncorrectSize => {
+                write!(f, "input is incorrect size to be a country tag")
+            }
+            Eu4ErrorKind::CountryTagInvalidCharacters => {
+                write!(f, "input contains invalid characters for a country tag")
+            }
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@ use std::io::Cursor;
 let data = std::fs::read("assets/saves/eng.txt.compressed.eu4")?;
 let (save, encoding) = Eu4Extractor::extract_save(Cursor::new(&data[..]))?;
 assert_eq!(encoding, Encoding::TextZip);
-assert_eq!(save.meta.player, CountryTag::from("ENG"));
+assert_eq!(save.meta.player, "ENG".parse()?);
 # Ok::<(), Box<dyn std::error::Error>>(())
 ```
 
@@ -37,7 +37,7 @@ use std::io::Cursor;
 let data = std::fs::read("assets/saves/eng.txt.compressed.eu4")?;
 let (save, _encoding) = Eu4Extractor::extract_save(Cursor::new(&data[..]))?;
 let save_query = Query::from_save(save);
-let trade = save_query.save().game.countries.get(&CountryTag::from("ENG"))
+let trade = save_query.save().game.countries.get(&"ENG".parse()?)
     .map(|country| save_query.country_income_breakdown(country))
     .map(|income| income.trade);
 assert_eq!(Some(17.982), trade);

--- a/tests/ironman.rs
+++ b/tests/ironman.rs
@@ -17,13 +17,13 @@ fn test_eu4_bin() {
     let data = utils::request("ragusa2.bin.eu4");
     let (save, encoding) = Eu4Extractor::extract_save(Cursor::new(&data[..])).unwrap();
     assert_eq!(encoding, Encoding::BinZip);
-    assert_eq!(save.meta.player, CountryTag::from("CRO"));
+    assert_eq!(save.meta.player, "CRO".parse().unwrap());
 
     let (save2, _) = Eu4Extractor::extract_meta_optimistic(Cursor::new(&data[..])).unwrap();
     assert!(save2.game.is_none());
 
     let query = Query::from_save(save);
-    assert_eq!(query.starting_country(), Some(&CountryTag::from("RAG")));
+    assert_eq!(query.starting_country(), Some(&"RAG".parse().unwrap()));
     assert_eq!(
         query
             .player_names()
@@ -34,23 +34,23 @@ fn test_eu4_bin() {
     );
 
     let mut players = HashSet::new();
-    players.insert(CountryTag::from("RAG"));
-    players.insert(CountryTag::from("CRO"));
+    players.insert("RAG".parse().unwrap());
+    players.insert("CRO".parse().unwrap());
     assert_eq!(query.player_countries(), &players);
 
     let expected_histories = vec![PlayerHistory {
-        tag: CountryTag::from("CRO"),
+        tag: "CRO".parse().unwrap(),
         is_human: true,
         exists: true,
         player_names: Vec::new(),
         played_tags: vec![
             CountryPlayed {
-                tag: CountryTag::from("RAG"),
+                tag: "RAG".parse().unwrap(),
                 start: Eu4Date::new(1444, 11, 11).unwrap(),
                 end: Eu4Date::new(1769, 1, 2).unwrap(),
             },
             CountryPlayed {
-                tag: CountryTag::from("CRO"),
+                tag: "CRO".parse().unwrap(),
                 start: Eu4Date::new(1769, 1, 2).unwrap(),
                 end: Eu4Date::new(1769, 1, 6).unwrap(),
             },
@@ -65,24 +65,24 @@ fn test_eu4_kandy_bin() {
     let data = utils::request("kandy2.bin.eu4");
     let (save, encoding) = Eu4Extractor::extract_save(Cursor::new(&data[..])).unwrap();
     assert_eq!(encoding, Encoding::BinZip);
-    assert_eq!(save.meta.player, CountryTag::from("BHA"));
+    assert_eq!(save.meta.player, "BHA".parse().unwrap());
 
     let query = Query::from_save(save);
     let mut players = HashSet::new();
-    players.insert(CountryTag::from("KND"));
-    players.insert(CountryTag::from("BHA"));
+    players.insert("KND".parse().unwrap());
+    players.insert("BHA".parse().unwrap());
     assert_eq!(query.player_countries(), &players);
 
     let player = query
         .save()
         .game
         .countries
-        .get(&CountryTag::from("BHA"))
+        .get(&"BHA".parse().unwrap())
         .unwrap();
     assert!(!player.completed_missions.is_empty());
 
     assert_eq!(
-        query.country_tag_hex_color(&CountryTag::from("BHA")),
+        query.country_tag_hex_color(&"BHA".parse().unwrap()),
         Some(String::from("#50a50a"))
     );
 
@@ -96,20 +96,20 @@ fn test_eu4_kandy_bin() {
             .owner
             .as_ref()
             .unwrap(),
-        &CountryTag::from("SCA")
+        &"SCA".parse().unwrap()
     );
 
-    assert_eq!(query.starting_country(), Some(&CountryTag::from("KND")));
+    assert_eq!(query.starting_country(), Some(&"KND".parse().unwrap()));
     assert_eq!(
         query.player_names().iter().cloned().collect::<Vec<_>>(),
         vec![String::from("comagoosie")]
     );
 
     let subjects: Vec<CountryTag> = vec![
-        CountryTag::from("TEO"),
-        CountryTag::from("YOK"),
-        CountryTag::from("C21"),
-        CountryTag::from("C23"),
+        "TEO".parse().unwrap(),
+        "YOK".parse().unwrap(),
+        "C21".parse().unwrap(),
+        "C23".parse().unwrap(),
     ];
 
     assert_eq!(
@@ -117,7 +117,7 @@ fn test_eu4_kandy_bin() {
             .save()
             .game
             .countries
-            .get(&CountryTag::from("BHA"))
+            .get(&"BHA".parse().unwrap())
             .unwrap()
             .subjects,
         subjects
@@ -128,12 +128,16 @@ fn test_eu4_kandy_bin() {
 
     // When querying for great powers in the ledger and a current great power is from a reformed
     // country (like russia or great britain), ensure that their predecessor is included.
-    let mos = ledgers.income.iter().find(|&x| x.name.as_str() == "MOS");
+    let mos = ledgers
+        .income
+        .iter()
+        .find(|&x| x.name == "MOS".parse().unwrap());
     assert!(mos.is_some());
 
     // I had a score of zero in 1450, but the ledger doesn't report zero values
     let knd_score = ledgers.score.iter().find(|&l| {
-        l.name.as_str() == "KND" && l.data.iter().find(|(x, y)| *x == 1450 && *y == 0).is_some()
+        l.name == "KND".parse().unwrap()
+            && l.data.iter().find(|(x, y)| *x == 1450 && *y == 0).is_some()
     });
     assert!(knd_score.is_some());
 
@@ -195,7 +199,7 @@ fn test_eu4_ita1() {
     let data = utils::request("ita1.eu4");
     let (save, encoding) = Eu4Extractor::extract_save(Cursor::new(&data[..])).unwrap();
     assert_eq!(encoding, Encoding::BinZip);
-    assert_eq!(save.meta.player, CountryTag::from("ITA"));
+    assert_eq!(save.meta.player, "ITA".parse().unwrap());
     let settings = &save.game.gameplay_settings.options;
     assert_eq!(settings.difficulty, GameDifficulty::Normal);
     assert_eq!(
@@ -212,7 +216,7 @@ fn test_eu4_ita1() {
     assert!(all_dlc_recognized);
 
     let query = Query::from_save(save);
-    assert_eq!(query.starting_country(), Some(&CountryTag::from("LAN")));
+    assert_eq!(query.starting_country(), Some(&"LAN".parse().unwrap()));
     assert_eq!(
         query.player_names().iter().cloned().collect::<Vec<_>>(),
         vec![String::from("comagoosie")]
@@ -225,7 +229,7 @@ fn test_roundtrip_melt() {
     let out = eu4save::melt(&data[..], eu4save::FailedResolveStrategy::Error).unwrap();
     let (save, encoding) = Eu4Extractor::extract_save(Cursor::new(&out[..])).unwrap();
     assert_eq!(encoding, Encoding::Text);
-    assert_eq!(save.meta.player, CountryTag::from("BHA"));
+    assert_eq!(save.meta.player, "BHA".parse().unwrap());
 }
 
 macro_rules! ironman_test {
@@ -247,7 +251,7 @@ macro_rules! ironman_test {
                     .unwrap();
                 assert_eq!(encoding, Encoding::BinZip);
                 let expected = $query;
-                assert_eq!(save.meta.player, CountryTag::from(expected.player));
+                assert_eq!(save.meta.player, expected.player.parse::<CountryTag>().unwrap());
                 assert_eq!(save.meta.date, expected.date);
 
                 let version = &save.meta.savegame_version;
@@ -264,7 +268,7 @@ macro_rules! ironman_test {
 
                 assert_eq!(
                     query.starting_country().unwrap(),
-                    &CountryTag::from(expected.starting)
+                    &expected.starting.parse::<CountryTag>().unwrap(),
                 );
 
                 ($further)(query);
@@ -313,23 +317,23 @@ ironman_test!(
 
 fn trycone_expected_histories() -> Vec<PlayerHistory> {
     vec![PlayerHistory {
-        tag: CountryTag::from("GBR"),
+        tag: "GBR".parse().unwrap(),
         is_human: true,
         exists: true,
         player_names: vec![String::from("comagoosie")],
         played_tags: vec![
             CountryPlayed {
-                tag: CountryTag::from("TYR"),
+                tag: "TYR".parse().unwrap(),
                 start: Eu4Date::new(1444, 11, 11).unwrap(),
                 end: Eu4Date::new(1518, 1, 29).unwrap(),
             },
             CountryPlayed {
-                tag: CountryTag::from("IRE"),
+                tag: "IRE".parse().unwrap(),
                 start: Eu4Date::new(1518, 1, 29).unwrap(),
                 end: Eu4Date::new(1606, 8, 4).unwrap(),
             },
             CountryPlayed {
-                tag: CountryTag::from("GBR"),
+                tag: "GBR".parse().unwrap(),
                 start: Eu4Date::new(1606, 8, 4).unwrap(),
                 end: Eu4Date::new(1725, 5, 12).unwrap(),
             },
@@ -353,23 +357,23 @@ ironman_test!(
 
 fn true_heir_expected_histories() -> Vec<PlayerHistory> {
     vec![PlayerHistory {
-        tag: CountryTag::from("MUG"),
+        tag: "MUG".parse().unwrap(),
         is_human: true,
         exists: true,
         player_names: vec![String::from("lambdax.x")],
         played_tags: vec![
             CountryPlayed {
-                tag: CountryTag::from("SIS"),
+                tag: "SIS".parse().unwrap(),
                 start: Eu4Date::new(1444, 11, 11).unwrap(),
                 end: Eu4Date::new(1467, 12, 3).unwrap(),
             },
             CountryPlayed {
-                tag: CountryTag::from("DLH"),
+                tag: "DLH".parse().unwrap(),
                 start: Eu4Date::new(1467, 12, 3).unwrap(),
                 end: Eu4Date::new(1467, 12, 3).unwrap(),
             },
             CountryPlayed {
-                tag: CountryTag::from("MUG"),
+                tag: "MUG".parse().unwrap(),
                 start: Eu4Date::new(1467, 12, 3).unwrap(),
                 end: Eu4Date::new(1508, 4, 27).unwrap(),
             },


### PR DESCRIPTION
Making CountryTag a newtype wrapper around String meant that it was
large (24 bytes + whatever on the heap). Since a country tag is only
three bytes long we can witness a 8x space savings by storing the three
bytes directly in the structure. This also makes CountryTag as Copyable
and more ergonomic to pass around.

In order to ensure invariants (that the country tag contains three bytes
that are alphanumeric or dashes) a country tag now validates data. This
has an ergonomic cost of needing to parse data into a country tag even
when the tag is constructed from a byte literal. We'll see how annoying
this turns out to be.