### PR TITLE
Rework query engine

### DIFF
--- a/src/bin/debug_save.rs
+++ b/src/bin/debug_save.rs
@@ -8,6 +8,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let file = File::open(&args[1])?;
     let reader = BufReader::new(file);
     let (save, _encoding) = Eu4Extractor::extract_save(reader)?;
-    print!("{:#?}", save.meta.date);
+
+    let query = eu4save::query::Query::from_save(save);
+    let owners = query.province_owners();
+    let nation_events = query.nation_events(&owners);
+    let player = query.player_histories(&nation_events);
+    let ledger = query.nation_size_statistics_ledger(&player[0].history);
+    println!("{}", ledger.len());
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,6 +77,7 @@ pub mod models;
 mod province_id;
 /// Ergonomic module for querying info from a save file
 pub mod query;
+mod tag_resolver;
 mod tokens;
 
 pub use country_tag::*;
@@ -87,3 +88,4 @@ pub use extraction::*;
 pub use jomini::FailedResolveStrategy;
 pub use melt::*;
 pub use province_id::*;
+pub use tag_resolver::*;

--- a/src/tag_resolver.rs
+++ b/src/tag_resolver.rs
@@ -1,0 +1,63 @@
+use crate::{
+    query::{NationEventKind, NationEvents},
+    CountryTag, Eu4Date,
+};
+use std::collections::HashMap;
+
+/// The tag resolver is important to answering questions like "where are they
+/// now?" when looking at historic events like province changes or wars. When
+/// countries tag switch the tag resolver is able to connect historic events
+/// to country's current selves. For instance in a TYR -> IRE -> GBR game, the
+/// provinces and wars gained while playing as TYR should still be aggregated
+/// under the current GBR tag.
+#[derive(Debug)]
+pub struct TagResolver {
+    initial_to_stored: HashMap<CountryTag, CountryTag>,
+    switches: HashMap<CountryTag, Vec<(Eu4Date, CountryTag)>>,
+}
+
+impl TagResolver {
+    pub fn create(nation_events: &[NationEvents]) -> Self {
+        let mut initial_to_stored = HashMap::with_capacity(nation_events.len());
+        for nation in nation_events.iter() {
+            initial_to_stored.insert(nation.initial, nation.stored);
+        }
+
+        let mut switches: HashMap<_, Vec<_>> = HashMap::new();
+        for nation in nation_events.iter().filter(|x| x.initial != x.stored) {
+            for event in &nation.events {
+                if let NationEventKind::TagSwitch(to) = event.kind {
+                    switches
+                        .entry(to)
+                        .or_insert_with(Vec::new)
+                        .push((event.date, nation.stored));
+                }
+            }
+        }
+
+        for entries in switches.values_mut() {
+            entries.sort_by_key(|(date, _)| *date);
+        }
+
+        TagResolver {
+            initial_to_stored,
+            switches,
+        }
+    }
+
+    /// Given a date and tag associated with the date, return the current tag where
+    /// the argument is stored.
+    pub fn resolve(&self, tag: CountryTag, date: Eu4Date) -> CountryTag {
+        self.switches
+            .get(&tag)
+            .and_then(|dates| {
+                dates
+                    .iter()
+                    .take_while(|(change_date, _)| *change_date < date)
+                    .last()
+            })
+            .map(|(_, stored)| *stored)
+            .or_else(|| self.initial_to_stored.get(&tag).cloned())
+            .unwrap_or(tag)
+    }
+}


### PR DESCRIPTION
Query engine now breaks individual steps apart so that the client can
better deal with the lifetimes of returned data.

Also this commit includes the ability to trace a tag to it's current
resting spot (eg: tag switches) given any date.