### PR TITLE
Rework melter API and add rewrite config

### DIFF
--- a/benches/eu4save_bench.rs
+++ b/benches/eu4save_bench.rs
@@ -8,7 +8,12 @@ pub fn melt_benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("melt");
     group.throughput(Throughput::Bytes(data.len() as u64));
     group.bench_function("metadata", |b| {
-        b.iter(|| eu4save::melt(data, eu4save::FailedResolveStrategy::Ignore).unwrap())
+        b.iter(|| {
+            eu4save::Melter::new()
+                .with_on_failed_resolve(eu4save::FailedResolveStrategy::Ignore)
+                .melt(data)
+                .unwrap()
+        })
     });
     group.finish();
 }

--- a/fuzz/fuzz_targets/fuzz_melt.rs
+++ b/fuzz/fuzz_targets/fuzz_melt.rs
@@ -2,5 +2,5 @@
 use libfuzzer_sys::fuzz_target;
 
 fuzz_target!(|data: &[u8]| {
-    let _ = eu4save::melt(&data, eu4save::FailedResolveStrategy::Ignore);
+    let _ = eu4save::Melter::new().with_on_failed_resolve(eu4save::FailedResolveStrategy::Ignore).melt(data);
 });

--- a/src/bin/melt.rs
+++ b/src/bin/melt.rs
@@ -5,7 +5,10 @@ use std::io::Write;
 fn main() {
     let args: Vec<String> = env::args().collect();
     let file_data = std::fs::read(&args[1]).unwrap();
-    let (melted, _tokens) = eu4save::melt(&file_data[..], FailedResolveStrategy::Error).unwrap();
+    let (melted, _tokens) = eu4save::Melter::new()
+        .with_on_failed_resolve(FailedResolveStrategy::Error)
+        .melt(&file_data[..])
+        .unwrap();
 
     let stdout = std::io::stdout();
     let mut handle = stdout.lock();

--- a/src/melt.rs
+++ b/src/melt.rs
@@ -1,222 +1,274 @@
-use crate::{tokens::TokenLookup, Eu4Date, Eu4Error, Eu4ErrorKind};
+use crate::{tokens::TokenLookup, Eu4Date, Eu4Error, Eu4ErrorKind, Extraction};
 use jomini::{BinaryTape, BinaryToken, FailedResolveStrategy, TokenResolver};
 use std::{
     collections::HashSet,
     io::{Cursor, Read, Write},
 };
 
-fn melter(
-    writer: &mut Vec<u8>,
-    unknown_tokens: &mut HashSet<u16>,
-    tape: &BinaryTape,
-    failed_resolver: FailedResolveStrategy,
-    write_checksum: bool,
-) -> Result<(), Eu4Error> {
-    let mut depth = 0;
-    let mut in_objects = Vec::new();
-    let mut in_object = 1;
-    let mut token_idx = 0;
-    let mut known_number = false;
-    let mut known_date = false;
-    let tokens = tape.tokens();
-
-    while let Some(token) = tokens.get(token_idx) {
-        let mut did_change = false;
-        if in_object == 1 {
-            let depth = match token {
-                BinaryToken::End(_) => depth - 1,
-                _ => depth,
-            };
-
-            for _ in 0..depth {
-                writer.push(b' ');
-            }
-        }
-
-        match token {
-            BinaryToken::Object(_) => {
-                did_change = true;
-                writer.extend_from_slice(b"{\n");
-                depth += 1;
-                in_objects.push(in_object);
-                in_object = 1;
-            }
-            BinaryToken::HiddenObject(_) => {
-                did_change = true;
-                depth += 1;
-                in_objects.push(in_object);
-                in_object = 1;
-            }
-            BinaryToken::Array(_) => {
-                did_change = true;
-                writer.push(b'{');
-                depth += 1;
-                in_objects.push(in_object);
-                in_object = 0;
-            }
-            BinaryToken::End(x) => {
-                if !matches!(tokens.get(*x), Some(BinaryToken::HiddenObject(_))) {
-                    writer.push(b'}');
-                }
-
-                let obj = in_objects.pop();
-
-                // The binary parser should already ensure that this will be something, but this is
-                // just a sanity check
-                debug_assert!(obj.is_some());
-                in_object = obj.unwrap_or(1);
-                depth -= 1;
-            }
-            BinaryToken::Bool(x) => match x {
-                true => writer.extend_from_slice(b"yes"),
-                false => writer.extend_from_slice(b"no"),
-            },
-            BinaryToken::U32(x) => writer.extend_from_slice(format!("{}", x).as_bytes()),
-            BinaryToken::U64(x) => writer.extend_from_slice(format!("{}", x).as_bytes()),
-            BinaryToken::I32(x) => {
-                if known_number {
-                    writer.extend_from_slice(format!("{}", x).as_bytes());
-                    known_number = false;
-                } else if known_date {
-                    if let Some(date) = Eu4Date::from_binary(*x) {
-                        writer.extend_from_slice(date.game_fmt().as_bytes());
-                    } else {
-                        return Err(Eu4Error::new(Eu4ErrorKind::InvalidDate(*x)));
-                    }
-                    known_date = false;
-                } else if let Some(date) = Eu4Date::from_binary_heuristic(*x) {
-                    writer.extend_from_slice(date.game_fmt().as_bytes());
-                } else {
-                    writer.extend_from_slice(format!("{}", x).as_bytes());
-                }
-            }
-            BinaryToken::Quoted(x) => {
-                let data = x.view_data();
-                let end_idx = match data.last() {
-                    Some(x) if *x == b'\n' => data.len() - 1,
-                    Some(_x) => data.len(),
-                    None => data.len(),
-                };
-
-                // quoted fields occuring as keys should remain unquoted
-                if in_object == 1 {
-                    writer.extend_from_slice(&data[..end_idx]);
-                } else {
-                    writer.push(b'"');
-                    writer.extend_from_slice(&data[..end_idx]);
-                    writer.push(b'"');
-                }
-            }
-            BinaryToken::Unquoted(x) => {
-                let data = x.view_data();
-                writer.extend_from_slice(&data);
-            }
-            BinaryToken::F32(x) => write!(writer, "{:.3}", x).map_err(Eu4ErrorKind::IoErr)?,
-            BinaryToken::F64(x) => write!(writer, "{:.5}", x).map_err(Eu4ErrorKind::IoErr)?,
-            BinaryToken::Token(x) => match TokenLookup.resolve(*x) {
-                Some(id)
-                    if (id == "is_ironman" || (id == "checksum" && !write_checksum))
-                        && in_object == 1 =>
-                {
-                    let skip = tokens
-                        .get(token_idx + 1)
-                        .map(|next_token| match next_token {
-                            BinaryToken::Object(end) => end + 1,
-                            BinaryToken::Array(end) => end + 1,
-                            _ => token_idx + 2,
-                        })
-                        .unwrap_or(token_idx + 1);
-
-                    token_idx = skip;
-                    continue;
-                }
-                Some(id) => {
-                    // There are certain tokens that we know are integers and will dupe the date heuristic
-                    known_number =
-                        in_object == 1 && (id == "random" || id.ends_with("seed") || id == "id");
-                    known_date = in_object == 1 && id == "date_built";
-                    writer.extend_from_slice(&id.as_bytes())
-                }
-                None => {
-                    unknown_tokens.insert(*x);
-                    match failed_resolver {
-                        FailedResolveStrategy::Error => {
-                            return Err(Eu4ErrorKind::UnknownToken { token_id: *x }.into());
-                        }
-                        FailedResolveStrategy::Ignore if in_object == 1 => {
-                            let skip = tokens
-                                .get(token_idx + 1)
-                                .map(|next_token| match next_token {
-                                    BinaryToken::Object(end) => end + 1,
-                                    BinaryToken::Array(end) => end + 1,
-                                    _ => token_idx + 2,
-                                })
-                                .unwrap_or(token_idx + 1);
-
-                            token_idx = skip;
-                            continue;
-                        }
-                        _ => {
-                            let unknown = format!("__unknown_0x{:x}", x);
-                            writer.extend_from_slice(unknown.as_bytes());
-                        }
-                    }
-                }
-            },
-            BinaryToken::Rgb(color) => {
-                writer.extend_from_slice(b"rgb {");
-                writer.extend_from_slice(format!("{} ", color.r).as_bytes());
-                writer.extend_from_slice(format!("{} ", color.g).as_bytes());
-                writer.extend_from_slice(format!("{}", color.b).as_bytes());
-                writer.push(b'}');
-            }
-        }
-
-        if !did_change && in_object == 1 {
-            writer.push(b'=');
-            in_object = 2;
-        } else if in_object == 2 {
-            in_object = 1;
-            writer.push(b'\n');
-        } else if in_object != 1 {
-            writer.push(b' ');
-        }
-
-        token_idx += 1;
-    }
-
-    Ok(())
+/// Convert ironman data to plaintext
+#[derive(Debug)]
+pub struct Melter {
+    on_failed_resolve: FailedResolveStrategy,
+    extraction: Extraction,
+    rewrite: bool,
 }
 
-fn melt_zip(
-    mut out: &mut Vec<u8>,
-    unknown_tokens: &mut HashSet<u16>,
-    zip_data: &[u8],
-    failed_resolver: FailedResolveStrategy,
-) -> Result<(), Eu4Error> {
-    let mut inflated_data = Vec::new();
+impl Default for Melter {
+    fn default() -> Self {
+        Melter {
+            extraction: Extraction::InMemory,
+            on_failed_resolve: FailedResolveStrategy::Ignore,
+            rewrite: true,
+        }
+    }
+}
 
-    let zip_reader = Cursor::new(&zip_data);
-    let mut zip = zip::ZipArchive::new(zip_reader).map_err(Eu4ErrorKind::ZipCentralDirectory)?;
+impl Melter {
+    /// Create a customized version to melt binary data
+    pub fn new() -> Self {
+        Melter::default()
+    }
 
-    // Pre-allocate enough data in the inflated data based on the uncompressed size of the ironman
-    // data
-    let size = zip
-        .by_name("gamestate")
-        .map_err(|e| Eu4ErrorKind::ZipMissingEntry("gamestate", e))
-        .map(|x| x.size())?;
-    out.reserve((size as usize) * 2);
+    /// Set the memory allocation extraction behavior for when a zip is encountered
+    pub fn with_extraction(mut self, extraction: Extraction) -> Self {
+        self.extraction = extraction;
+        self
+    }
 
-    for file in &["meta", "gamestate", "ai"] {
-        inflated_data.clear();
-        let mut zip_file = zip
-            .by_name(file)
-            .map_err(|e| Eu4ErrorKind::ZipMissingEntry(file, e))?;
+    /// Set the behavior for when an unresolved binary token is encountered
+    pub fn with_on_failed_resolve(mut self, strategy: FailedResolveStrategy) -> Self {
+        self.on_failed_resolve = strategy;
+        self
+    }
 
-        zip_file
-            .read_to_end(&mut inflated_data)
-            .map_err(|e| Eu4ErrorKind::ZipExtraction(file, e))?;
+    /// Set if the melter should rewrite properties to better match the plaintext format
+    ///
+    /// Setting to false will preserve binary fields and values even if they
+    /// don't make any sense in the plaintext output.
+    pub fn with_rewrite(mut self, rewrite: bool) -> Self {
+        self.rewrite = rewrite;
+        self
+    }
 
+    /// Convert ironman data to plaintext
+    pub fn melt(&self, data: &[u8]) -> Result<(Vec<u8>, HashSet<u16>), Eu4Error> {
+        let mut out: Vec<u8> = b"EU4txt\n".to_vec();
+        let mut unknown_tokens = HashSet::new();
+
+        let is_zip = data
+            .get(..4)
+            .map_or(false, |x| x == &[0x50, 0x4b, 0x03, 0x04][..]);
+
+        if is_zip {
+            self.melt_zip(&mut out, &mut unknown_tokens, &data)?;
+        } else {
+            out.reserve(data.len() * 2);
+            let cut_header_len = if data
+                .get(..b"EU4bin".len())
+                .map_or(false, |x| x == &b"EU4bin"[..])
+            {
+                "EU4bin".len()
+            } else {
+                0
+            };
+            let tape = BinaryTape::from_eu4(&data[cut_header_len..])?;
+            self.convert(&mut out, &mut unknown_tokens, &tape, true)?;
+        }
+
+        Ok((out, unknown_tokens))
+    }
+
+    fn convert(
+        &self,
+        writer: &mut Vec<u8>,
+        unknown_tokens: &mut HashSet<u16>,
+        tape: &BinaryTape,
+        write_checksum: bool,
+    ) -> Result<(), Eu4Error> {
+        let mut depth = 0;
+        let mut in_objects = Vec::new();
+        let mut in_object = 1;
+        let mut token_idx = 0;
+        let mut known_number = false;
+        let mut known_date = false;
+        let tokens = tape.tokens();
+
+        while let Some(token) = tokens.get(token_idx) {
+            let mut did_change = false;
+            if in_object == 1 {
+                let depth = match token {
+                    BinaryToken::End(_) => depth - 1,
+                    _ => depth,
+                };
+
+                for _ in 0..depth {
+                    writer.push(b' ');
+                }
+            }
+
+            match token {
+                BinaryToken::Object(_) => {
+                    did_change = true;
+                    writer.extend_from_slice(b"{\n");
+                    depth += 1;
+                    in_objects.push(in_object);
+                    in_object = 1;
+                }
+                BinaryToken::HiddenObject(_) => {
+                    did_change = true;
+                    depth += 1;
+                    in_objects.push(in_object);
+                    in_object = 1;
+                }
+                BinaryToken::Array(_) => {
+                    did_change = true;
+                    writer.push(b'{');
+                    depth += 1;
+                    in_objects.push(in_object);
+                    in_object = 0;
+                }
+                BinaryToken::End(x) => {
+                    if !matches!(tokens.get(*x), Some(BinaryToken::HiddenObject(_))) {
+                        writer.push(b'}');
+                    }
+
+                    let obj = in_objects.pop();
+
+                    // The binary parser should already ensure that this will be something, but this is
+                    // just a sanity check
+                    debug_assert!(obj.is_some());
+                    in_object = obj.unwrap_or(1);
+                    depth -= 1;
+                }
+                BinaryToken::Bool(x) => match x {
+                    true => writer.extend_from_slice(b"yes"),
+                    false => writer.extend_from_slice(b"no"),
+                },
+                BinaryToken::U32(x) => writer.extend_from_slice(format!("{}", x).as_bytes()),
+                BinaryToken::U64(x) => writer.extend_from_slice(format!("{}", x).as_bytes()),
+                BinaryToken::I32(x) => {
+                    if known_number {
+                        writer.extend_from_slice(format!("{}", x).as_bytes());
+                        known_number = false;
+                    } else if known_date {
+                        if let Some(date) = Eu4Date::from_binary(*x) {
+                            writer.extend_from_slice(date.game_fmt().as_bytes());
+                        } else {
+                            return Err(Eu4Error::new(Eu4ErrorKind::InvalidDate(*x)));
+                        }
+                        known_date = false;
+                    } else if let Some(date) = Eu4Date::from_binary_heuristic(*x) {
+                        writer.extend_from_slice(date.game_fmt().as_bytes());
+                    } else {
+                        writer.extend_from_slice(format!("{}", x).as_bytes());
+                    }
+                }
+                BinaryToken::Quoted(x) => {
+                    let data = x.view_data();
+                    let end_idx = match data.last() {
+                        Some(x) if *x == b'\n' => data.len() - 1,
+                        Some(_x) => data.len(),
+                        None => data.len(),
+                    };
+
+                    // quoted fields occuring as keys should remain unquoted
+                    if in_object == 1 {
+                        writer.extend_from_slice(&data[..end_idx]);
+                    } else {
+                        writer.push(b'"');
+                        writer.extend_from_slice(&data[..end_idx]);
+                        writer.push(b'"');
+                    }
+                }
+                BinaryToken::Unquoted(x) => {
+                    let data = x.view_data();
+                    writer.extend_from_slice(&data);
+                }
+                BinaryToken::F32(x) => write!(writer, "{:.3}", x).map_err(Eu4ErrorKind::IoErr)?,
+                BinaryToken::F64(x) => write!(writer, "{:.5}", x).map_err(Eu4ErrorKind::IoErr)?,
+                BinaryToken::Token(x) => match TokenLookup.resolve(*x) {
+                    Some(id)
+                        if ((self.rewrite && id == "is_ironman")
+                            || (id == "checksum" && !write_checksum))
+                            && in_object == 1 =>
+                    {
+                        let skip = tokens
+                            .get(token_idx + 1)
+                            .map(|next_token| match next_token {
+                                BinaryToken::Object(end) => end + 1,
+                                BinaryToken::Array(end) => end + 1,
+                                _ => token_idx + 2,
+                            })
+                            .unwrap_or(token_idx + 1);
+
+                        token_idx = skip;
+                        continue;
+                    }
+                    Some(id) => {
+                        // There are certain tokens that we know are integers and will dupe the date heuristic
+                        known_number = in_object == 1
+                            && (id == "random" || id.ends_with("seed") || id == "id");
+                        known_date = in_object == 1 && id == "date_built";
+                        writer.extend_from_slice(&id.as_bytes())
+                    }
+                    None => {
+                        unknown_tokens.insert(*x);
+                        match self.on_failed_resolve {
+                            FailedResolveStrategy::Error => {
+                                return Err(Eu4ErrorKind::UnknownToken { token_id: *x }.into());
+                            }
+                            FailedResolveStrategy::Ignore if in_object == 1 => {
+                                let skip = tokens
+                                    .get(token_idx + 1)
+                                    .map(|next_token| match next_token {
+                                        BinaryToken::Object(end) => end + 1,
+                                        BinaryToken::Array(end) => end + 1,
+                                        _ => token_idx + 2,
+                                    })
+                                    .unwrap_or(token_idx + 1);
+
+                                token_idx = skip;
+                                continue;
+                            }
+                            _ => {
+                                let unknown = format!("__unknown_0x{:x}", x);
+                                writer.extend_from_slice(unknown.as_bytes());
+                            }
+                        }
+                    }
+                },
+                BinaryToken::Rgb(color) => {
+                    writer.extend_from_slice(b"rgb {");
+                    writer.extend_from_slice(format!("{} ", color.r).as_bytes());
+                    writer.extend_from_slice(format!("{} ", color.g).as_bytes());
+                    writer.extend_from_slice(format!("{}", color.b).as_bytes());
+                    writer.push(b'}');
+                }
+            }
+
+            if !did_change && in_object == 1 {
+                writer.push(b'=');
+                in_object = 2;
+            } else if in_object == 2 {
+                in_object = 1;
+                writer.push(b'\n');
+            } else if in_object != 1 {
+                writer.push(b' ');
+            }
+
+            token_idx += 1;
+        }
+
+        Ok(())
+    }
+
+    fn melt_zip_entry(
+        &self,
+        mut out: &mut Vec<u8>,
+        unknown_tokens: &mut HashSet<u16>,
+        inflated_data: &[u8],
+        file: &str,
+    ) -> Result<(), Eu4Error> {
         let tape = BinaryTape::from_eu4(&inflated_data["EU4bin".len()..]).map_err(|e| {
             Eu4ErrorKind::Deserialize {
                 part: Some(file.to_string()),
@@ -224,58 +276,66 @@ fn melt_zip(
             }
         })?;
 
-        let write_checksum = file == &"ai";
-        melter(
-            &mut out,
-            unknown_tokens,
-            &tape,
-            failed_resolver,
-            write_checksum,
-        )?;
+        let write_checksum = file == "ai";
+        self.convert(&mut out, unknown_tokens, &tape, write_checksum)
     }
 
-    Ok(())
-}
+    fn melt_zip(
+        &self,
+        out: &mut Vec<u8>,
+        unknown_tokens: &mut HashSet<u16>,
+        zip_data: &[u8],
+    ) -> Result<(), Eu4Error> {
+        let zip_reader = Cursor::new(&zip_data);
+        let mut zip =
+            zip::ZipArchive::new(zip_reader).map_err(Eu4ErrorKind::ZipCentralDirectory)?;
 
-/// Convert ironman data to plaintext
-pub fn melt(
-    data: &[u8],
-    failed_resolver: FailedResolveStrategy,
-) -> Result<(Vec<u8>, HashSet<u16>), Eu4Error> {
-    let mut out: Vec<u8> = b"EU4txt\n".to_vec();
-    let mut unknown_tokens = HashSet::new();
+        // Pre-allocate enough data in the inflated data based on the uncompressed size of the ironman
+        // data
+        let size = zip
+            .by_name("gamestate")
+            .map_err(|e| Eu4ErrorKind::ZipMissingEntry("gamestate", e))
+            .map(|x| x.size())?;
+        out.reserve((size as usize) * 2);
 
-    let is_zip = data
-        .get(..4)
-        .map_or(false, |x| x == &[0x50, 0x4b, 0x03, 0x04][..]);
+        for file in &["meta", "gamestate", "ai"] {
+            let mut zip_file = zip
+                .by_name(file)
+                .map_err(|e| Eu4ErrorKind::ZipMissingEntry(file, e))?;
 
-    if is_zip {
-        melt_zip(&mut out, &mut unknown_tokens, &data, failed_resolver)?;
-    } else {
-        out.reserve(data.len() * 2);
-        let cut_header_len = if data
-            .get(..b"EU4bin".len())
-            .map_or(false, |x| x == &b"EU4bin"[..])
-        {
-            "EU4bin".len()
-        } else {
-            0
-        };
-        let tape = BinaryTape::from_eu4(&data[cut_header_len..])?;
-        melter(&mut out, &mut unknown_tokens, &tape, failed_resolver, true)?;
+            match self.extraction {
+                Extraction::InMemory => {
+                    let mut inflated_data: Vec<u8> = Vec::with_capacity(size as usize);
+                    zip_file
+                        .read_to_end(&mut inflated_data)
+                        .map_err(|e| Eu4ErrorKind::ZipExtraction(file, e))?;
+                    self.melt_zip_entry(out, unknown_tokens, &inflated_data, file)?
+                }
+
+                #[cfg(feature = "mmap")]
+                Extraction::MmapTemporaries => {
+                    let mut mmap = memmap::MmapMut::map_anon(zip_file.size() as usize)?;
+                    std::io::copy(&mut zip_file, &mut mmap.as_mut())
+                        .map_err(|e| Eu4ErrorKind::ZipExtraction(file, e))?;
+                    self.melt_zip_entry(out, unknown_tokens, &mmap[..], file)?
+                }
+            }
+        }
+
+        Ok(())
     }
-
-    Ok((out, unknown_tokens))
 }
 
-#[cfg(all(test, ironman_tokens))]
+#[cfg(all(test, ironman))]
 mod tests {
     use super::*;
 
     #[test]
     fn test_short_input_regression() {
         // Make sure it doesn't crash
-        let _ = melt(&[], FailedResolveStrategy::Error);
+        let _ = Melter::new()
+            .with_on_failed_resolve(FailedResolveStrategy::Error)
+            .melt(&[]);
     }
 
     #[test]
@@ -284,22 +344,31 @@ mod tests {
             45, 2, 1, 0, 1, 137, 1, 45, 1, 0, 67, 2, 0, 255, 255, 255, 255, 226, 2, 1, 0, 1, 137,
             1, 45, 1, 56, 226, 1, 255, 255, 255, 255, 255,
         ];
-        let _ = melt(&data, FailedResolveStrategy::Ignore);
+        let _ = Melter::new()
+            .with_on_failed_resolve(FailedResolveStrategy::Ignore)
+            .melt(&data);
     }
 
     #[test]
     fn test_ironman_nonscalar() {
         let data = [137, 53, 3, 0, 4, 0];
         let expected = b"EU4txt\n";
-        let out = melt(&data[..], FailedResolveStrategy::Error).unwrap();
+        let (out, _unknown) = Melter::new()
+            .with_on_failed_resolve(FailedResolveStrategy::Error)
+            .melt(&data)
+            .unwrap();
         assert_eq!(out, &expected[..]);
     }
 
     #[test]
     fn test_melt_meta() {
-        let meta = include_bytes!("../tests/fixtures/meta.bin");
-        let expected = include_bytes!("../tests/fixtures/meta.bin.melted");
-        let out = melt(&meta[..], FailedResolveStrategy::Error).unwrap();
+        let meta = include_bytes!("../tests/it/fixtures/meta.bin");
+        let expected = include_bytes!("../tests/it/fixtures/meta.bin.melted");
+        let (out, _unknown) = Melter::new()
+            .with_on_failed_resolve(FailedResolveStrategy::Error)
+            .melt(&meta[..])
+            .unwrap();
+        std::fs::write("/tmp/abcout", &out).unwrap();
         assert_eq!(out, &expected[..]);
     }
 
@@ -311,8 +380,11 @@ mod tests {
             0x00, 0x03, 0x00, 0x42, 0x48, 0x41,
         ];
 
-        let expected = b"EU4txt\ndate=1804.12.09\nplayer=\"BHA\"\n";
-        let out = melt(&data[..], FailedResolveStrategy::Error).unwrap();
+        let expected = b"EU4txt\ndate=1804.12.9\nplayer=\"BHA\"\n";
+        let (out, _unknown) = Melter::new()
+            .with_on_failed_resolve(FailedResolveStrategy::Error)
+            .melt(&data)
+            .unwrap();
         assert_eq!(out, &expected[..]);
     }
 
@@ -327,7 +399,10 @@ mod tests {
         data.extend_from_slice(&0x0004u16.to_le_bytes());
 
         let expected = b"EU4txt\nflags={\n schools_initiated=\"1444.11.11\"\n}\n";
-        let out = melt(&data[..], FailedResolveStrategy::Error).unwrap();
+        let (out, _unknown) = Melter::new()
+            .with_on_failed_resolve(FailedResolveStrategy::Error)
+            .melt(&data)
+            .unwrap();
         assert_eq!(out, &expected[..]);
     }
 
@@ -340,7 +415,10 @@ mod tests {
         ];
 
         let expected = b"EU4txt\nplayer=\"BHA\"\n";
-        let out = melt(&data[..], FailedResolveStrategy::Ignore).unwrap();
+        let (out, _unknown) = Melter::new()
+            .with_on_failed_resolve(FailedResolveStrategy::Ignore)
+            .melt(&data)
+            .unwrap();
         assert_eq!(out, &expected[..]);
     }
 
@@ -353,7 +431,10 @@ mod tests {
         ];
 
         let expected = b"EU4txt\ndate=__unknown_0xffff\nplayer=\"BHA\"\n";
-        let out = melt(&data[..], FailedResolveStrategy::Ignore).unwrap();
+        let (out, _unknown) = Melter::new()
+            .with_on_failed_resolve(FailedResolveStrategy::Ignore)
+            .melt(&data)
+            .unwrap();
         assert_eq!(out, &expected[..]);
     }
 }

--- a/tests/it/fixtures/meta.bin.melted
+++ b/tests/it/fixtures/meta.bin.melted
@@ -1,5 +1,5 @@
 EU4txt
-date=1597.01.15
+date=1597.1.15
 save_game="ragusa2.eu4"
 player="RAG"
 displayed_country_name="Ragusa"
@@ -27,12 +27,12 @@ campaign_stats={ {
   comparison=2
   key="longest_reign"
   localization="Isidoro Vucic"
-  value=12
+  value=12.000
  } {
   id=2
   comparison=2
   key="wars_won"
-  value=12
+  value=12.000
  } {
   id=3
   comparison=2
@@ -41,36 +41,36 @@ campaign_stats={ {
   id=4
   comparison=2
   key="army_kills"
-  value=187848.98
+  value=187848.984
   sample_count=153
  } {
   id=5
   comparison=2
   key="army_losses"
-  value=105943
+  value=105943.000
   sample_count=153
  } {
   id=6
   comparison=2
   key="navy_kills"
-  value=12
+  value=12.000
   sample_count=153
  } {
   id=7
   comparison=2
   key="navy_losses"
-  value=1
+  value=1.000
   sample_count=153
  } {
   id=8
   comparison=2
   key="countries_removed"
-  value=2
+  value=2.000
  } {
   id=9
   comparison=2
   key="provs_taken"
-  value=19
+  value=19.000
  } {
   id=10
   comparison=2
@@ -79,13 +79,13 @@ campaign_stats={ {
   id=11
   comparison=0
   key="leader_count"
-  value=36
+  value=36.000
  } {
   id=12
   comparison=0
   key="best_leader"
   localization="§GGiulio Vucic§! ( 4 / 3 / 3 / 2 )"
-  value=19
+  value=19.000
  } {
   id=13
   comparison=1
@@ -97,7 +97,7 @@ campaign_stats={ {
   comparison=2
   key="best_prov"
   localization="Dubrovnik"
-  value=21
+  value=21.000
  } {
   id=15
   comparison=2

--- a/tests/it/ironman.rs
+++ b/tests/it/ironman.rs
@@ -210,7 +210,11 @@ fn test_eu4_ita1() {
 #[test]
 fn test_roundtrip_melt() {
     let data = utils::request("kandy2.bin.eu4");
-    let (out, _unknown) = eu4save::melt(&data[..], eu4save::FailedResolveStrategy::Error).unwrap();
+    let (out, _unknown) = eu4save::Melter::new()
+        .with_on_failed_resolve(FailedResolveStrategy::Error)
+        .melt(&data[..])
+        .unwrap();
+
     let (save, encoding) = Eu4Extractor::extract_save(Cursor::new(&out[..])).unwrap();
     assert_eq!(encoding, Encoding::Text);
     assert_eq!(save.meta.player, "BHA".parse().unwrap());
@@ -226,7 +230,11 @@ macro_rules! ironman_test {
                 // Ensure that every ironman can be melted with all tokens resolvable.
                 // Deserialization will not try and resolve tokens that aren't used. Melting
                 // ensures that every token is seen
-                let (melted, _) = eu4save::melt(&data[..], FailedResolveStrategy::Error).unwrap();
+                let (melted, _) = eu4save::Melter::new()
+                    .with_on_failed_resolve(FailedResolveStrategy::Error)
+                    .melt(&data[..])
+                    .unwrap();
+
                 assert!(!melted.is_empty());
 
                 let (save, encoding) = Eu4ExtractorBuilder::new()


### PR DESCRIPTION
This makes the melter API symmetrical to the other melters and adds in
the rewrite config to dictate if some values that are specific to the
binary format should be preserved (the default is rewrite or skip them).