### PR TITLE
Allow customizing how tokens are resolved

### DIFF
--- a/src/bin/debug_save.rs
+++ b/src/bin/debug_save.rs
@@ -7,7 +7,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args: Vec<String> = env::args().collect();
     let file = File::open(&args[1])?;
     let reader = BufReader::new(file);
-    let (save, _encoding) = Eu4Extractor::extract_save(reader)?;
+    let (save, _encoding) = Eu4Extractor::builder().extract_save(reader)?;
 
     let query = eu4save::query::Query::from_save(save);
     let owners = query.province_owners();


### PR DESCRIPTION
Previously one had to specify the tokens through environment variable
pointing to a defined format file. This is not a great idea as there is
no customization possible. Instead this PR allows one to pass in how
tokens are resolved, while keeping it backwards compatible for those
using the environment variable.