### PR TITLE
Improve melting accuracy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ mmap = ['memmap']
 serialize = []
 
 [dependencies]
-jomini = "0.17"
+jomini = "0.18"
 once_cell = "1"
 zip = { version =  "0.5", default-features = false, features = ["deflate"] }
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
Some changes

- The AI file / section has 6 decimal precision instead of 3
- `culture_group` has keys that are quoted
- `flags` (among many others) keys should always be unquoted
- `subjects` is quoted when seen as a scalar but not when it's a list
- `tribal_owner` is unquoted when outside the province history, but quoted inside
- Melted output no longer ends with a newline as that would break
  loading the save from the in game menu