### PR TITLE
Force specific TokenResolver for deserialization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ specta = ["dep:specta"]
 
 [dependencies]
 jomini = { version = "0.27.2", features = ["json"] }
-zip = { version =  "0.6", default-features = false }
 serde = { version = "1", features = ["derive"] }
 thiserror = "1"
 zstd = { version = "0.13", default-features = false, optional = true }

--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@
 EU4 Save is a library to ergonomically work with EU4 saves (ironman + mp).
 
 ```rust
-use eu4save::{Eu4File, Encoding, CountryTag, EnvTokens};
+use eu4save::{Eu4File, Encoding, CountryTag, SegmentedResolver};
 let data = std::fs::read("assets/saves/eng.txt.compressed.eu4")?;
 let file = Eu4File::from_slice(&data)?;
-let save = file.parse_save(&EnvTokens)?;
+let save = file.parse_save(&SegmentedResolver)?;
 assert_eq!(file.encoding(), Encoding::TextZip);
 assert_eq!(save.meta.player, "ENG".parse()?);
 ```

--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -21,8 +21,10 @@ path = "src/bench.rs"
 
 [dependencies]
 criterion = "0.5.1"
+erased-serde = "0.4.5"
 eu4save = { path = "../" }
 rawzip = "0.0.5"
+serde_path_to_error = "0.1.16"
 
 [profile.release]
 debug = true

--- a/bench/src/bench.rs
+++ b/bench/src/bench.rs
@@ -11,14 +11,14 @@ fn parse_save(c: &mut Criterion) {
         total_size += entry.uncompressed_size_hint();
     }
 
-    let file_data = std::fs::read("../assets/eu4.txt").unwrap();
-    let tokens = eu4save::BasicTokenResolver::from_text_lines(file_data.as_slice()).unwrap();
+    let file_data = std::fs::read("../assets/eu4.txt").unwrap_or_default();
+    let segments = eu4save::SegmentedResolver::parse(file_data.as_slice()).unwrap();
 
     group.throughput(Throughput::Bytes(total_size as u64));
     group.bench_function("text", |b| {
         b.iter(|| {
             let file = eu4save::Eu4File::from_slice(&data).unwrap();
-            let _ = file.parse_save(&tokens);
+            let _ = file.parse_save(&segments.resolver());
         })
     });
     group.finish();

--- a/bench/src/bench.rs
+++ b/bench/src/bench.rs
@@ -21,6 +21,48 @@ fn parse_save(c: &mut Criterion) {
             let _ = file.parse_save(&segments.resolver());
         })
     });
+
+    let data = std::fs::read("../assets/saves/kandy2.bin.eu4").unwrap();
+    let zip = rawzip::ZipArchive::from_slice(&data).unwrap();
+    let mut entries = zip.entries();
+    let mut total_size = 0;
+    while let Some(entry) = entries.next_entry().unwrap() {
+        total_size += entry.uncompressed_size_hint();
+    }
+
+    group.throughput(Throughput::Bytes(total_size as u64));
+    group.bench_function("binary", |b| {
+        b.iter(|| {
+            let file = eu4save::Eu4File::from_slice(&data).unwrap();
+            let _ = file.parse_save(&segments.resolver());
+        })
+    });
+
+    group.bench_function("debug", |b| {
+        b.iter(|| {
+            let file = eu4save::Eu4File::from_slice(&data).unwrap();
+            let eu4save::file::Eu4SliceFileKind::Zip(zip) = file.kind() else {
+                return;
+            };
+
+            let resolver = segments.resolver();
+            let meta = zip.get(eu4save::file::Eu4FileEntryName::Meta).unwrap();
+            let mut deser = eu4save::file::Eu4Modeller::from_reader(meta, &resolver);
+            let mut track = serde_path_to_error::Track::new();
+            let deser = serde_path_to_error::Deserializer::new(&mut deser, &mut track);
+            let mut erased = <dyn erased_serde::Deserializer>::erase(deser);
+            let meta = erased_serde::deserialize(&mut erased).unwrap();
+
+            let gamestate = zip.get(eu4save::file::Eu4FileEntryName::Gamestate).unwrap();
+            let mut deser = eu4save::file::Eu4Modeller::from_reader(gamestate, &resolver);
+            let mut track = serde_path_to_error::Track::new();
+            let deser = serde_path_to_error::Deserializer::new(&mut deser, &mut track);
+            let mut erased = <dyn erased_serde::Deserializer>::erase(deser);
+            let game = erased_serde::deserialize(&mut erased).unwrap();
+
+            let _ = eu4save::models::Eu4Save { meta, game };
+        })
+    });
     group.finish();
 }
 

--- a/fuzz/fuzz_targets/fuzz_extract.rs
+++ b/fuzz/fuzz_targets/fuzz_extract.rs
@@ -1,19 +1,19 @@
 #![no_main]
-use eu4save::{file::Eu4ParsedText, BasicTokenResolver};
+use eu4save::{file::Eu4ParsedText, SegmentedResolver, SegmentedResolverBuilder};
 use libfuzzer_sys::fuzz_target;
 use std::sync::LazyLock;
 
-static TOKENS: LazyLock<BasicTokenResolver> = LazyLock::new(|| {
-    let file_data = std::fs::read("assets/eu4.txt").unwrap();
-    BasicTokenResolver::from_text_lines(file_data.as_slice()).unwrap()
+static TOKENS: LazyLock<SegmentedResolverBuilder> = LazyLock::new(|| {
+    let file_data = std::fs::read("assets/eu4.txt").unwrap_or_default();
+    SegmentedResolver::parse(file_data.as_slice()).unwrap()
 });
 
 fn run(data: &[u8]) -> Result<(), Box<dyn std::error::Error>> {
     let file = eu4save::Eu4File::from_slice(&data)?;
 
     let mut sink = std::io::sink();
-    let _ = file.melt(eu4save::MeltOptions::new(), &*TOKENS, &mut sink);
-    let _ = file.parse_save(&*TOKENS);
+    let _ = file.melt(eu4save::MeltOptions::new(), &TOKENS.resolver(), &mut sink);
+    let _ = file.parse_save(&TOKENS.resolver());
     let _ = file.size();
     let _ = file.encoding();
 

--- a/src/bin/cli/csv.rs
+++ b/src/bin/cli/csv.rs
@@ -1,4 +1,4 @@
-use eu4save::{BasicTokenResolver, Eu4File, PdsDate};
+use eu4save::{Eu4File, PdsDate, SegmentedResolver};
 use std::error::Error;
 
 pub fn run(path: &str) -> Result<(), Box<dyn Error>> {
@@ -6,7 +6,8 @@ pub fn run(path: &str) -> Result<(), Box<dyn Error>> {
     let file = Eu4File::from_file(file)?;
 
     let file_data = std::fs::read("assets/eu4.txt").unwrap_or_default();
-    let resolver = BasicTokenResolver::from_text_lines(file_data.as_slice())?;
+    let resolver_builder = SegmentedResolver::parse(file_data.as_slice())?;
+    let resolver = resolver_builder.resolver();
     let save = file.parse_save(&resolver)?;
 
     println!("date,tag,prestige");

--- a/src/bin/cli/debug_save.rs
+++ b/src/bin/cli/debug_save.rs
@@ -1,4 +1,4 @@
-use eu4save::{BasicTokenResolver, Eu4File};
+use eu4save::{Eu4File, SegmentedResolver};
 use std::{error::Error, time::Instant};
 
 pub fn run(path: &str) -> Result<(), Box<dyn Error>> {
@@ -7,7 +7,8 @@ pub fn run(path: &str) -> Result<(), Box<dyn Error>> {
 
     let start = Instant::now();
     let file_data = std::fs::read("assets/eu4.txt").unwrap_or_default();
-    let resolver = BasicTokenResolver::from_text_lines(file_data.as_slice())?;
+    let resolver_builder = SegmentedResolver::parse(file_data.as_slice())?;
+    let resolver = resolver_builder.resolver();
     let save = file.parse_save(&resolver)?;
     let after_parse = Instant::now();
     println!("parse: {}ms", after_parse.duration_since(start).as_millis());

--- a/src/bin/cli/deducer.rs
+++ b/src/bin/cli/deducer.rs
@@ -1,4 +1,4 @@
-use eu4save::{BasicTokenResolver, CountryTag, Eu4File};
+use eu4save::{CountryTag, Eu4File, SegmentedResolver};
 use std::{collections::HashSet, error::Error, fmt::Display};
 
 #[derive(Debug)]
@@ -50,7 +50,8 @@ pub fn run(path: &str) -> Result<(), Box<dyn Error>> {
     let file = Eu4File::from_file(file)?;
 
     let file_data = std::fs::read("assets/eu4.txt").unwrap_or_default();
-    let resolver = BasicTokenResolver::from_text_lines(file_data.as_slice())?;
+    let resolver_builder = SegmentedResolver::parse(file_data.as_slice())?;
+    let resolver = resolver_builder.resolver();
     let save = file.parse_save(&resolver)?;
     deduce_vec(
         save.game

--- a/src/bin/cli/json.rs
+++ b/src/bin/cli/json.rs
@@ -26,7 +26,7 @@ pub fn run(path: &str) -> Result<(), Box<dyn Error>> {
         }
         Eu4FsFileKind::Binary(x) => {
             let mut buf = Vec::new();
-            x.melt(melt_options, resolver, &mut buf)?;
+            x.as_ref().melt(melt_options, resolver, &mut buf)?;
             let text = Eu4ParsedText::from_slice(&buf)?;
             json_to_stdout(&text);
         }

--- a/src/bin/cli/melt.rs
+++ b/src/bin/cli/melt.rs
@@ -3,7 +3,7 @@ use std::{error::Error, io::BufWriter};
 
 pub fn run(path: &str) -> Result<(), Box<dyn Error>> {
     let file = std::fs::File::open(path)?;
-    let mut file = Eu4File::from_file(file)?;
+    let file = Eu4File::from_file(file)?;
 
     let stdout = std::io::stdout();
     let handle = stdout.lock();

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,7 +1,6 @@
 use crate::file::Eu4FileEntryName;
 use jomini::binary;
 use std::{fmt, io};
-use zip::result::ZipError;
 
 /// An EU4 Error
 #[derive(thiserror::Error, Debug)]
@@ -30,15 +29,6 @@ impl From<Eu4ErrorKind> for Eu4Error {
 pub enum Eu4ErrorKind {
     #[error("zip error: {0}")]
     Zip(#[from] rawzip::Error),
-
-    #[error("unable to parse as zip: {0}")]
-    ZipArchive(#[from] ZipError),
-
-    #[error("unable to inflate zip entry: {msg}")]
-    ZipBadData { msg: String },
-
-    #[error("early eof, only able to write {written} bytes")]
-    ZipEarlyEof { written: usize },
 
     #[error("unknown header found in zip entry. Must be EU4txt or EU4bin")]
     ZipHeader,
@@ -75,6 +65,9 @@ pub enum Eu4ErrorKind {
 
     #[error("io error: {0}")]
     Io(#[from] io::Error),
+
+    #[error("invalid syntax: {0}")]
+    InvalidSyntax(String),
 }
 
 impl From<jomini::Error> for Eu4Error {

--- a/src/file.rs
+++ b/src/file.rs
@@ -99,10 +99,7 @@ where
         Eu4Binary(&self.0)
     }
 
-    pub fn deserializer<'a, 'b>(
-        self,
-        resolver: &'a SegmentedResolver<'b>,
-    ) -> Eu4Modeller<'a, 'b>
+    pub fn deserializer<'a, 'b>(self, resolver: &'a SegmentedResolver<'b>) -> Eu4Modeller<'a, 'b>
     where
         R: Read + 'a,
     {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,12 +3,11 @@ EU4 Save is a library to ergonomically work with EU4 saves (ironman + mp).
 
 ```rust
 use std::collections::HashMap;
-use eu4save::{Eu4File, Encoding, CountryTag};
+use eu4save::{Eu4File, Encoding, CountryTag, SegmentedResolver};
 
 let data = std::fs::read("assets/saves/eng.txt.compressed.eu4")?;
 let file = Eu4File::from_slice(&data)?;
-let resolver = HashMap::<u16, &str>::new();
-let save = file.parse_save(&resolver)?;
+let save = file.parse_save(&SegmentedResolver::empty())?;
 assert_eq!(file.encoding(), Encoding::TextZip);
 assert_eq!(save.meta.player, "ENG");
 # Ok::<(), Box<dyn std::error::Error>>(())
@@ -31,12 +30,11 @@ To help solve questions like these, the `Query` API was created
 
 ```rust
 use std::collections::HashMap;
-use eu4save::{Eu4File, Encoding, CountryTag, query::Query};
+use eu4save::{Eu4File, Encoding, CountryTag, query::Query, SegmentedResolver};
 
 let data = std::fs::read("assets/saves/eng.txt.compressed.eu4")?;
 let file = Eu4File::from_slice(&data)?;
-let resolver = HashMap::<u16, &str>::new();
-let save = file.parse_save(&resolver)?;
+let save = file.parse_save(&SegmentedResolver::empty())?;
 let save_query = Query::from_save(save);
 let trade = save_query.country(&"ENG".parse()?)
     .map(|country| save_query.country_income_breakdown(country))
@@ -66,6 +64,7 @@ pub mod models;
 mod province_id;
 /// Ergonomic module for querying info from a save file
 pub mod query;
+mod resolver;
 mod tag_resolver;
 
 pub use country_tag::*;
@@ -77,4 +76,5 @@ pub use file::Eu4File;
 pub use jomini::binary::{BasicTokenResolver, FailedResolveStrategy};
 pub use melt::*;
 pub use province_id::*;
+pub use resolver::{SegmentedResolver, SegmentedResolverBuilder};
 pub use tag_resolver::*;

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -1,0 +1,118 @@
+use std::io::BufRead;
+
+use crate::{Eu4Error, Eu4ErrorKind};
+
+pub struct SegmentedResolver<'a> {
+    values: Vec<&'a str>,
+
+    // First sequence spans from 0 to lower_sequence_end
+    lower_sequence_end: u16,
+
+    // Upper sequence starts at upper_sequence_start, but is stored contiguously
+    // after lower_sequence
+    upper_sequence_start: u16,
+}
+
+impl<'a> SegmentedResolver<'a> {
+    pub const fn empty() -> SegmentedResolver<'static> {
+        SegmentedResolver {
+            values: Vec::new(),
+            lower_sequence_end: 0,
+            upper_sequence_start: 0,
+        }
+    }
+
+    pub fn from_parts(
+        values: Vec<&'a str>,
+        lower_sequence_end: u16,
+        upper_sequence_start: u16,
+    ) -> SegmentedResolver<'a> {
+        SegmentedResolver {
+            values,
+            lower_sequence_end,
+            upper_sequence_start,
+        }
+    }
+
+    /// Create resolver from a `BufRead` implementation over a space delimited
+    /// text format:
+    ///
+    /// ```plain
+    /// 0xffff my_test_token
+    /// 0xeeee my_test_token2
+    /// ```
+    pub fn parse<T>(mut data: T) -> Result<SegmentedResolverBuilder, Eu4Error>
+    where
+        T: BufRead,
+    {
+        let mut result = Vec::new();
+        let mut line = String::new();
+        while data.read_line(&mut line)? != 0 {
+            let (num, text) = line.split_once(' ').ok_or_else(|| {
+                Eu4Error::from(Eu4ErrorKind::InvalidSyntax(String::from(
+                    "expected to split line",
+                )))
+            })?;
+
+            let z = u16::from_str_radix(num.trim_start_matches("0x"), 16).map_err(|_| {
+                Eu4Error::from(Eu4ErrorKind::InvalidSyntax(String::from(
+                    "invalid ironman token",
+                )))
+            })?;
+
+            if result.len() <= z as usize {
+                result.resize(z as usize + 1, String::from(""));
+            }
+            result[z as usize] = String::from(text.trim_end());
+            line.clear();
+        }
+
+        let lower_sequence_end = result.len() as u16;
+        Ok(SegmentedResolverBuilder {
+            values: result,
+            lower_sequence_end,
+            upper_sequence_start: 0,
+        })
+    }
+}
+
+impl jomini::binary::TokenResolver for SegmentedResolver<'_> {
+    fn resolve(&self, token: u16) -> Option<&str> {
+        let ind = if token < self.lower_sequence_end {
+            usize::from(token)
+        } else if token >= self.upper_sequence_start {
+            usize::from(token - self.upper_sequence_start + self.lower_sequence_end)
+        } else {
+            return None;
+        };
+
+        match self.values.get(ind) {
+            Some(&"") | None => None,
+            Some(x) => Some(*x),
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.values.is_empty()
+    }
+}
+
+pub struct SegmentedResolverBuilder {
+    values: Vec<String>,
+    lower_sequence_end: u16,
+    upper_sequence_start: u16,
+}
+
+impl SegmentedResolverBuilder {
+    pub fn is_empty(&self) -> bool {
+        self.values.is_empty()
+    }
+
+    pub fn resolver(&self) -> SegmentedResolver {
+        SegmentedResolver {
+            values: self.values.iter().map(|x| x.as_str()).collect(),
+            lower_sequence_end: self.lower_sequence_end,
+            upper_sequence_start: self.upper_sequence_start,
+        }
+    }
+}

--- a/tests/it/ironman.rs
+++ b/tests/it/ironman.rs
@@ -7,15 +7,14 @@ use eu4save::{
         CountryManaUsage, LedgerPoint, NationEvent, NationEventKind, NationEvents, PlayerHistory,
         Query,
     },
-    BasicTokenResolver, CountryTag, Encoding, Eu4Date, Eu4File, FailedResolveStrategy, MeltOptions,
-    PdsDate, ProvinceId,
+    CountryTag, Encoding, Eu4Date, Eu4File, FailedResolveStrategy, MeltOptions, PdsDate,
+    ProvinceId, SegmentedResolver, SegmentedResolverBuilder,
 };
-use jomini::binary::TokenResolver;
 use paste::paste;
 
-static TOKENS: LazyLock<BasicTokenResolver> = LazyLock::new(|| {
+static TOKENS: LazyLock<SegmentedResolverBuilder> = LazyLock::new(|| {
     let file_data = std::fs::read("assets/eu4.txt").unwrap_or_default();
-    BasicTokenResolver::from_text_lines(file_data.as_slice()).unwrap()
+    SegmentedResolver::parse(file_data.as_slice()).unwrap()
 });
 
 macro_rules! skip_if_no_tokens {
@@ -31,7 +30,7 @@ fn test_eu4_bin() {
     skip_if_no_tokens!();
     let file = utils::request_file("ragusa2.bin.eu4");
     let file = Eu4File::from_file(file).unwrap();
-    let save = file.parse_save(&*TOKENS).unwrap();
+    let save = file.parse_save(&TOKENS.resolver()).unwrap();
     assert_eq!(file.encoding(), Encoding::BinaryZip);
     assert_eq!(save.meta.player, "CRO");
 
@@ -66,7 +65,7 @@ fn test_eu4_kandy_bin() {
     skip_if_no_tokens!();
     let file = utils::request_file("kandy2.bin.eu4");
     let file = Eu4File::from_file(file).unwrap();
-    let save = file.parse_save(&*TOKENS).unwrap();
+    let save = file.parse_save(&TOKENS.resolver()).unwrap();
     assert_eq!(file.encoding(), Encoding::BinaryZip);
     assert_eq!(save.meta.player, "BHA");
 
@@ -166,7 +165,7 @@ fn test_eu4_kandy_bin_zst() {
     skip_if_no_tokens!();
     let file = utils::request_file("kandy2.bin.zst.eu4");
     let file = Eu4File::from_file(file).unwrap();
-    let save = file.parse_save(&*TOKENS).unwrap();
+    let save = file.parse_save(&TOKENS.resolver()).unwrap();
     assert_eq!(file.encoding(), Encoding::BinaryZip);
     assert_eq!(save.meta.player, "BHA");
 }
@@ -178,8 +177,8 @@ fn test_eu4_same_campaign_id() {
     let file2 = utils::request_file("ita2_later.eu4");
     let file = Eu4File::from_file(file).unwrap();
     let file2 = Eu4File::from_file(file2).unwrap();
-    let save = file.parse_save(&*TOKENS).unwrap();
-    let save2 = file2.parse_save(&*TOKENS).unwrap();
+    let save = file.parse_save(&TOKENS.resolver()).unwrap();
+    let save2 = file2.parse_save(&TOKENS.resolver()).unwrap();
     assert_eq!(save.meta.campaign_id, save2.meta.campaign_id);
     assert!(save.meta.date < save2.meta.date);
 }
@@ -189,7 +188,7 @@ fn test_eu4_ita1() {
     skip_if_no_tokens!();
     let file = utils::request_file("ita1.eu4");
     let file = Eu4File::from_file(file).unwrap();
-    let save = file.parse_save(&*TOKENS).unwrap();
+    let save = file.parse_save(&TOKENS.resolver()).unwrap();
     assert_eq!(file.encoding(), Encoding::BinaryZip);
     assert_eq!(save.meta.player, "ITA");
     let settings = &save.game.gameplay_settings.options;
@@ -222,7 +221,7 @@ fn test_inheritance_values() {
     skip_if_no_tokens!();
     let file = utils::request_file("patch132.eu4");
     let file = Eu4File::from_file(file).unwrap();
-    let save = file.parse_save(&*TOKENS).unwrap();
+    let save = file.parse_save(&TOKENS.resolver()).unwrap();
     let query = Query::from_save(save);
 
     let inherit = query.inherit(&query.save_country(&"WUR".parse().unwrap()).unwrap());
@@ -245,13 +244,13 @@ fn test_roundtrip_melt() {
     let mut out = Cursor::new(Vec::new());
     file.melt(
         MeltOptions::new().on_failed_resolve(FailedResolveStrategy::Error),
-        &*TOKENS,
+        &TOKENS.resolver(),
         &mut out,
     )
     .unwrap();
 
     let file = Eu4File::from_slice(out.get_ref().as_slice()).unwrap();
-    let save = file.parse_save(&*TOKENS).unwrap();
+    let save = file.parse_save(&TOKENS.resolver()).unwrap();
     assert_eq!(file.encoding(), Encoding::Text);
     assert_eq!(save.meta.player, "BHA");
 }
@@ -271,11 +270,11 @@ macro_rules! ironman_test {
                 let mut out = Cursor::new(Vec::new());
                 file.melt(
                     MeltOptions::new().on_failed_resolve(FailedResolveStrategy::Error),
-                    &*TOKENS,
+                    &TOKENS.resolver(),
                     &mut out,
                 ).unwrap();
 
-                let save = file.parse_save(&*TOKENS).unwrap();
+                let save = file.parse_save(&TOKENS.resolver()).unwrap();
 
                 assert_eq!(file.encoding(), Encoding::BinaryZip);
                 let expected = $query;

--- a/tests/it/ironman.rs
+++ b/tests/it/ironman.rs
@@ -240,7 +240,7 @@ fn test_inheritance_values() {
 fn test_roundtrip_melt() {
     skip_if_no_tokens!();
     let file = utils::request_file("kandy2.bin.eu4");
-    let mut file = Eu4File::from_file(file).unwrap();
+    let file = Eu4File::from_file(file).unwrap();
     let mut out = Cursor::new(Vec::new());
     file.melt(
         MeltOptions::new().on_failed_resolve(FailedResolveStrategy::Error),
@@ -262,7 +262,7 @@ macro_rules! ironman_test {
             fn [<test_ $name>]() {
                 skip_if_no_tokens!();
                 let file = utils::request_file($fp);
-                let mut file = Eu4File::from_file(file).unwrap();
+                let file = Eu4File::from_file(file).unwrap();
 
                 // Ensure that every ironman can be melted with all tokens resolvable.
                 // Deserialization will not try and resolve tokens that aren't used. Melting

--- a/tests/it/samples.rs
+++ b/tests/it/samples.rs
@@ -6,7 +6,7 @@ use eu4save::{
         BuildingConstruction, BuildingEvent, NationEvent, NationEventKind, NationEvents,
         PlayerHistory, Query,
     },
-    Encoding, Eu4Date, Eu4File, PdsDate, ProvinceId,
+    Encoding, Eu4Date, Eu4File, PdsDate, ProvinceId, SegmentedResolver,
 };
 use std::{collections::HashMap, error::Error};
 
@@ -16,7 +16,7 @@ fn test_eu4_text() -> Result<(), Box<dyn Error>> {
     let data = utils::inflate(file);
 
     let file = Eu4File::from_slice(&data)?;
-    let save = file.parse_save(HashMap::<u16, &str>::new())?;
+    let save = file.parse_save(&SegmentedResolver::empty())?;
 
     assert_eq!(file.encoding(), Encoding::Text);
     assert_eq!(save.meta.player, "ENG");
@@ -81,7 +81,7 @@ fn test_eu4_text() -> Result<(), Box<dyn Error>> {
 fn test_eu4_compressed_text() -> Result<(), Box<dyn Error>> {
     let data = utils::request_file("eng.txt.compressed.eu4");
     let file = Eu4File::from_file(data)?;
-    let save = file.parse_save(HashMap::<u16, &str>::new())?;
+    let save = file.parse_save(&SegmentedResolver::empty())?;
     assert_eq!(file.encoding(), Encoding::TextZip);
     assert_eq!(save.meta.player, "ENG");
 
@@ -98,7 +98,7 @@ fn test_eu4_compressed_text_raw() -> Result<(), Box<dyn Error>> {
     };
 
     let mut meta_entry = zip.get(Eu4FileEntryName::Meta)?;
-    let meta: Meta = meta_entry.deserialize(HashMap::<u16, &str>::new())?;
+    let meta: Meta = meta_entry.deserialize(&SegmentedResolver::empty())?;
 
     assert_eq!(file.encoding(), Encoding::TextZip);
     assert_eq!(meta.player, "ENG");
@@ -109,7 +109,7 @@ fn test_eu4_compressed_text_raw() -> Result<(), Box<dyn Error>> {
 pub fn parse_multiplayer_saves() -> Result<(), Box<dyn Error>> {
     let data = utils::request_file("mp_Uesugi.eu4");
     let file = Eu4File::from_file(data)?;
-    let save = file.parse_save(HashMap::<u16, &str>::new())?;
+    let save = file.parse_save(&SegmentedResolver::empty())?;
     assert!(save.meta.multiplayer);
 
     let query = Query::from_save(save);
@@ -309,7 +309,7 @@ pub fn parse_multiplayer_saves() -> Result<(), Box<dyn Error>> {
 pub fn parse_overflowing_losses() -> Result<(), Box<dyn Error>> {
     let data = utils::request_file("losses.eu4");
     let file = Eu4File::from_file(data)?;
-    let save = file.parse_save(HashMap::<u16, &str>::new())?;
+    let save = file.parse_save(&SegmentedResolver::empty())?;
     let country_negative_loss = save
         .game
         .countries
@@ -326,7 +326,7 @@ fn test_missing_leader_activation_save() -> Result<(), Box<dyn Error>> {
     let data = utils::inflate(file);
 
     let file = Eu4File::from_slice(&data)?;
-    let save = file.parse_save(HashMap::<u16, &str>::new())?;
+    let save = file.parse_save(&SegmentedResolver::empty())?;
     assert_eq!(file.encoding(), Encoding::Text);
     assert_eq!(save.meta.player, "NED");
 
@@ -359,7 +359,7 @@ fn test_handle_heavily_nested_events() {
     // fires. https://eu4.paradoxwikis.com/English_events#Symposium
     let data = utils::request_file("HashMP_Game56_S7End.eu4");
     let file = Eu4File::from_file(data).unwrap();
-    let _save = file.parse_save(HashMap::<u16, &str>::new()).unwrap();
+    let _save = file.parse_save(&SegmentedResolver::empty()).unwrap();
     assert_eq!(file.encoding(), Encoding::TextZip);
 }
 
@@ -368,7 +368,7 @@ fn test_paperman_text() -> Result<(), Box<dyn Error>> {
     let file = utils::request_file("paperman.eu4.zip");
     let data = utils::inflate(file);
     let file = Eu4File::from_slice(&data).unwrap();
-    let save = file.parse_save(HashMap::<u16, &str>::new()).unwrap();
+    let save = file.parse_save(&SegmentedResolver::empty()).unwrap();
     assert_eq!(file.encoding(), Encoding::Text);
     assert_eq!(save.meta.player, "GER");
     Ok(())
@@ -378,5 +378,5 @@ fn test_paperman_text() -> Result<(), Box<dyn Error>> {
 fn fix_crash_on_long_country_tag_debug_mode() {
     let file = std::fs::File::open("tests/it/fixtures/crash1.bin").unwrap();
     let file = Eu4File::from_file(file).unwrap();
-    let _save = file.parse_save(HashMap::<u16, &str>::new());
+    let _save = file.parse_save(&SegmentedResolver::empty());
 }


### PR DESCRIPTION
So we don't monomorphize the deserialization structure more than we need to. Should save on compile times and Wasm size